### PR TITLE
fixing the linting checker

### DIFF
--- a/lambda_functions/raijin_log_extractor/raijin_log_extractor.py
+++ b/lambda_functions/raijin_log_extractor/raijin_log_extractor.py
@@ -160,6 +160,7 @@ class S3Handler(object):
         return self
 
     def __next__(self):
+        # pylint: disable=unsubscriptable-object
         if self.curr >= len(self.s3_objects):
             raise StopIteration
 

--- a/lambda_functions/raijin_log_extractor/test_raijin_log_extractor.py
+++ b/lambda_functions/raijin_log_extractor/test_raijin_log_extractor.py
@@ -6,7 +6,7 @@ import io
 from raijin_log_extractor import ESHandler, handler
 
 
-class test_eshandler(unittest.TestCase):
+class TestESHandler(unittest.TestCase):
 
     metadata = {
         'pbs_job_id': 'test-job-id',
@@ -48,7 +48,7 @@ class test_eshandler(unittest.TestCase):
         assert len(es.log_data['unstructured']) == 1
 
 
-class test_handler(unittest.TestCase):
+class TestHandler(unittest.TestCase):
 
     METADATA = {
         'pbs_job_id': 'test-job-id',

--- a/lambda_modules/dea_es/__init__.py
+++ b/lambda_modules/dea_es/__init__.py
@@ -1,0 +1,1 @@
+# This file allows the linter to read from the directory

--- a/lambda_modules/dea_es/dea_es/config.py
+++ b/lambda_modules/dea_es/dea_es/config.py
@@ -16,8 +16,8 @@ if _AWS_ES_ACCESS_KEY:
 elif not _AWS_ES_ACCESS_KEY and DEA_ENVIRONMENT == 'dev':
     # Allow users to test with their local aws credentials
     import logging
-    logger = logging.getLogger(__name__)
-    logger.warn('WARNING: Using local aws access credentials, please set environment variables on lambda function')
+    LOGGER = logging.getLogger(__name__)
+    LOGGER.warning('WARNING: Using local aws access credentials, please set environment variables on lambda function')
 
     with open(os.path.expanduser('~/.aws/credentials'), 'r') as fd:
         for line in fd.readlines():

--- a/lambda_modules/dea_raijin/__init__.py
+++ b/lambda_modules/dea_raijin/__init__.py
@@ -1,0 +1,1 @@
+# This file allows the linter to read from the directory

--- a/lambda_modules/dea_raijin/dea_raijin/auth/raijin_ssh.py
+++ b/lambda_modules/dea_raijin/dea_raijin/auth/raijin_ssh.py
@@ -168,6 +168,7 @@ class RaijinSession(object):
             (int): Exit code of the command
 
         """
+        # pylint: disable=broad-except
         if not self.ssh_client:
             self.connect()
         stdin, stdout, stderr, exit_code = None, None, None, None

--- a/lambda_modules/dea_raijin/tests/lambda_commands_test.py
+++ b/lambda_modules/dea_raijin/tests/lambda_commands_test.py
@@ -5,6 +5,7 @@ import dea_raijin
 from dea_raijin.lambda_commands import BaseCommand, RaijinCommand
 
 
+# pylint: disable=abstract-method
 class BC(BaseCommand):
     '''Blank class to test default behaviour'''
     def __init__(self):

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -4,7 +4,7 @@
 set -eu
 set -x
 {
-    LINT_ARGS="$(find raijin_scripts/. lambda_modules/. lambda_functions/. -iname '*.py')"
+    LINT_ARGS="lambda_modules/*/* $(find raijin_scripts/. lambda_functions/. -iname '*.py')"
 } &> /dev/null
 
 python3 -m pep8 $LINT_ARGS 

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -3,10 +3,13 @@
 
 set -eu
 set -x
+{
+    LINT_ARGS="$(find raijin_scripts/. lambda_modules/. lambda_functions/. -iname '*.py')"
+} &> /dev/null
 
-python3 -m pep8 lambda_functions lambda_modules raijin_scripts --max-line-length 120
+python3 -m pep8 $LINT_ARGS 
 
-python3 -m pylint -j 2 --reports no lambda_modules lambda_functions raijin_scripts
+python3 -m pylint -j 2 --reports no $LINT_ARGS 
 
 # Run tests, taking coverage.
 # Users can specify extra folders as arguments.

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -4,7 +4,7 @@
 set -eu
 set -x
 {
-    LINT_ARGS="lambda_modules/*/* $(find raijin_scripts/. lambda_functions/. -iname '*.py')"
+    LINT_ARGS="lambda_modules/* $(find raijin_scripts/. lambda_functions/. -iname '*.py')"
 } &> /dev/null
 
 python3 -m pep8 $LINT_ARGS 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [pep8]
 max-line-length = 120
+exclude = *.pyc
+filename = *.py


### PR DESCRIPTION
Disabled some of the pylint errors and made sure it was actually running against files.

120 character limit is defined in setup.cfg