### PR TITLE
Add lambda for executing stacker on the NCI

### DIFF
--- a/lambda_functions/execute_fractional_cover/env_vars.json
+++ b/lambda_functions/execute_fractional_cover/env_vars.json
@@ -1,3 +1,6 @@
 {
-  "default":  {}
+  "PROJECT": "v10",
+  "QUEUE": "normal",
+  "FC_MODULE": "fc/1.2.4",
+  "DEA_MODULE": "dea-prod/20171019"
 }

--- a/lambda_functions/execute_stacker/env_vars.json
+++ b/lambda_functions/execute_stacker/env_vars.json
@@ -1,0 +1,5 @@
+{
+  "PROJECT": "v10",
+  "QUEUE": "normal",
+  "DEA_MODULE": "dea-prod/20171101"
+}

--- a/lambda_functions/execute_stacker/execute_stacker.py
+++ b/lambda_functions/execute_stacker/execute_stacker.py
@@ -1,0 +1,29 @@
+import logging
+import os
+
+from dea_raijin.auth import RaijinSession
+from dea_raijin import OrchestratorException
+
+LOG = logging.getLogger(__file__)
+
+
+def handler(event, context):
+    year = event['year']
+    app_config_file = event['app_config_file']
+
+    dea_module = os.environ['DEA_MODULE']
+    project = os.environ['PROJECT']
+    queue = os.environ['QUEUE']
+
+    with RaijinSession(logger=LOG) as raijin:
+        stdout, stderr, exit_code = raijin.exec_command(f'execute_stacker'
+                                                        f' --year {year}'
+                                                        f' --app-config-file {app_config_file}'
+                                                        f' --dea-module {dea_module}'
+                                                        f' --queue {queue}'
+                                                        f' --project {project}')
+        if exit_code != 0:
+            raise OrchestratorException(f"Error executing fractional cover for {year} {app_config_file}",
+                                        stdout=stdout, stderr=stderr, exit_code=exit_code)
+
+    return dict(stdout=stdout, stderr=stderr, exit_code=exit_code)

--- a/lambda_functions/execute_stacker/requirements.txt
+++ b/lambda_functions/execute_stacker/requirements.txt
@@ -1,0 +1,1 @@
+./lambda_modules/dea_raijin

--- a/raijin_scripts/execute_fractional_cover/run
+++ b/raijin_scripts/execute_fractional_cover/run
@@ -46,7 +46,4 @@ module load "${FC_MODULE}"
 APP_CONFIG=$(datacube-fc list | grep "${OUTPUT_PRODUCT}")
 
 
-
-datacube-fc submit --project "${PROJECT}" --queue "${QUEUE}" --year "${YEAR}" --app-config "${APP_CONFIG}" --tag "${TAG}"
-
-# TODO: what's happening with the logging??
+datacube-fc submit -v -v --project "${PROJECT}" --queue "${QUEUE}" --year "${YEAR}" --app-config "${APP_CONFIG}" --tag "${TAG}"

--- a/raijin_scripts/execute_stacker/run
+++ b/raijin_scripts/execute_stacker/run
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eu
+
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case ${key} in
+        --year )                shift
+                                YEAR=$1
+                                ;;
+        --app-config-file )     shift
+                                APP_CONFIG_FILE=$1
+                                ;;
+        --dea-module )          shift
+                                DEA_MODULE=$1
+                                ;;
+        --queue )               shift
+                                QUEUE=$1
+                                ;;
+        --project )             shift
+                                PROJECT=$1
+                                ;;
+        * )                     exit 1
+    esac
+    shift
+done
+
+
+echo Executing stacker for "${YEAR}" "${APP_CONFIG_FILE}"
+echo Loading module "${DEA_MODULE}"
+
+module use /g/data/v10/public/modules/modulefiles
+module use /g/data/v10/private/modules/modulefiles
+
+module load "${DEA_MODULE}"
+
+dea-stacker submit -v -v --project "${PROJECT}" --queue "${QUEUE}" --year "${YEAR}" --app-config "${APP_CONFIG_FILE}"


### PR DESCRIPTION
Adds a lambda called `execute_stacker` for queueing and running stacker on the NCI. 

It uses the new `dea-stacker` command available from GeoscienceAustralia/digitalearthau#48. Input arguments are `year` and `app_config_file` provided in the lambda event, and `DEA_MODULE`, `PROJECT` and `QUEUE` from lambda environment variables.

The code is very similar to `execute_fractional_cover`, and adds both a simple lambda handler and a simple raijin script.