### PR TITLE
Automate ingest on Raijin

### DIFF
--- a/lambda_functions/execute_ingest_js/README.md
+++ b/lambda_functions/execute_ingest_js/README.md
@@ -1,0 +1,13 @@
+
+
+## Setup
+
+Since this plugin uses the Serverless plugin `serverless-secrets-plugin` you need to setup the `node_modules` by running:
+
+    npm install
+
+## Deploy
+
+In order to deploy the endpoint, simply run:
+
+    serverless deploy

--- a/lambda_functions/execute_ingest_js/handler.js
+++ b/lambda_functions/execute_ingest_js/handler.js
@@ -1,0 +1,63 @@
+'use strict';
+const SSH = require('simple-ssh');
+
+const AWS = require("aws-sdk");
+AWS.config.update({region: 'ap-southeast-2'});
+
+const ssm = new AWS.SSM();
+
+let hostkey = 'orchestrator.raijin.users.default.host';
+let userkey = 'orchestrator.raijin.users.default.user';
+let pkey = 'orchestrator.raijin.users.default.pkey';
+
+// See https://hackernoon.com/you-should-use-ssm-parameter-store-over-lambda-env-variables-5197fc6ea45b
+// For a more advanced way of loading data from SSM using KSM
+// Or look at https://github.com/n1ru4l/ssm-parameter-env
+
+module.exports.execute_ingest = (event, context, callback) => {
+    let dea_module = process.env.DEA_MODULE;
+    let project = process.env.PROJECT;
+    let queue = process.env.QUEUE;
+    let product = event['product'];
+    let year = event['year'];
+
+    if (typeof year !== 'string') {
+        return callback('Year not specified');
+    }
+    if (typeof product !== 'string') {
+        return callback('Product not specified');
+    }
+
+    let req = {
+        Names: [hostkey, userkey, pkey],
+        WithDecryption: true
+    };
+    ssm.getParameters(req, function(err, data) {
+
+        let params = {};
+        for (let p of data.Parameters) {
+            params[p.Name] = p.Value;
+        }
+
+        let ssh = new SSH({
+            host: params[hostkey],
+            user: params[userkey],
+            key: params[pkey],
+        });
+
+        let command = `execute_ingest --dea-module ${dea_module} --project ${project} --queue ${queue} --product ${product} --year ${year}`;
+        console.log(`Executing: ${command}`);
+        ssh.exec(command, {
+            out: function(stdout) {
+                console.log(stdout);
+                const response = { statusCode: 200, body: 'Ingestion queued.' };
+                callback(null, response);
+            },
+            err: function(stderr) {
+                callback(`SSH Failed ${stderr}`);
+            }
+        }).start();
+
+    });
+
+};

--- a/lambda_functions/execute_ingest_js/package.json
+++ b/lambda_functions/execute_ingest_js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "execute_ingest_js",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "dependencies": {
+    "simple-ssh": "^1.0.0",
+    "serverless-pseudo-parameters": "^1.6.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/lambda_functions/execute_ingest_js/serverless.yml
+++ b/lambda_functions/execute_ingest_js/serverless.yml
@@ -1,0 +1,47 @@
+# Welcome to Serverless!
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: execute-ingest # NOTE: update this with your service name
+
+plugins:
+  - serverless-pseudo-parameters
+
+provider:
+  name: aws
+  runtime: nodejs6.10
+  environment:
+    DEA_MODULE: dea/20180515
+    PROJECT: v10
+    QUEUE: normal
+  region: ap-southeast-2
+  stackTags:
+    repo: dea-orchestration
+    author: damien.ayers@ga.gov.au
+    purpose: nci-automation
+# you can add statements to the Lambda function's IAM Role here
+  iamRoleStatements:
+    - Effect: 'Allow'
+      Action:
+        - 'ssm:GetParameters'
+        - 'ssm:DescribeParameters'
+      Resource:
+        - "arn:aws:ssm:#{AWS::Region}:#{AWS::AccountId}:parameter/orchestrator.*"
+        - "arn:aws:ssm:#{AWS::Region}:#{AWS::AccountId}:parameter/pipeline.*"
+    - Effect: 'Allow'
+      Action: 'kms:Decrypt'
+      Resource:
+        - "arn:aws:kms:#{AWS::Region}:#{AWS::AccountId}:key/efba9b4c-8e64-430c-86c9-f00eaf69e582"
+
+functions:
+  execute_ingest:
+    handler: handler.execute_ingest
+    events:
+      - schedule:
+          rate: cron(0 14 * * ? *) # Run daily, at midnight Canberra time
+          input:
+            year: 2018
+            product: ls8_nbar_albers

--- a/lambda_functions/execute_stacker/execute_stacker.py
+++ b/lambda_functions/execute_stacker/execute_stacker.py
@@ -23,7 +23,7 @@ def handler(event, context):
                                                         f' --queue {queue}'
                                                         f' --project {project}')
         if exit_code != 0:
-            raise OrchestratorException(f"Error executing fractional cover for {year} {app_config_file}",
+            raise OrchestratorException(f"Error executing stacker for {year} {app_config_file}",
                                         stdout=stdout, stderr=stderr, exit_code=exit_code)
 
     return dict(stdout=stdout, stderr=stderr, exit_code=exit_code)

--- a/pylintrc
+++ b/pylintrc
@@ -1,152 +1,528 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
 [MESSAGES CONTROL]
-disable=no-self-use,
-    star-args,
-    duplicate-code,
-    unused-argument,
-    missing-docstring,
-    no-member,
-    unused-variable,
-    unused-import,
-    locally-disabled,
-    no-name-in-module,
-    fixme,
-    no-value-for-parameter,
-    file-ignored,
-    wrong-import-order,
-    ungrouped-imports,
-    bad-whitespace,
-    len-as-condition,
-    arguments-differ,
 
-# Disabled len-as-condition: Sometimes this allows more readable code as it's more explicit.
-# Eg.
-#      if dataset.uris is not None and len(dataset.uris) == 0:
-# vs
-#      if dataset.uris is not None and not dataset.uris:
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=missing-docstring,
+        bad-whitespace,
+        wrong-import-order,
+        ungrouped-imports,
+        len-as-condition,
+        no-name-in-module,
+        no-member,
+        no-value-for-parameter,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        no-self-use,
+        duplicate-code,
+        arguments-differ,
+        fixme,
+        unused-import,
+        unused-variable,
+        unused-argument
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=print-statement,
+       parameter-unpacking,
+       unpacking-in-except,
+       old-raise-syntax,
+       backtick,
+       long-suffix,
+       old-ne-operator,
+       old-octal-literal,
+       import-star-module-level,
+       non-ascii-bytes-literal,
+       invalid-unicode-literal,
+       c-extension-no-member,
+       apply-builtin,
+       basestring-builtin,
+       buffer-builtin,
+       cmp-builtin,
+       coerce-builtin,
+       execfile-builtin,
+       file-builtin,
+       long-builtin,
+       raw_input-builtin,
+       reduce-builtin,
+       standarderror-builtin,
+       unicode-builtin,
+       xrange-builtin,
+       coerce-method,
+       delslice-method,
+       getslice-method,
+       setslice-method,
+       no-absolute-import,
+       old-division,
+       dict-iter-method,
+       dict-view-method,
+       next-method-called,
+       metaclass-assignment,
+       indexing-exception,
+       raising-string,
+       reload-builtin,
+       oct-method,
+       hex-method,
+       nonzero-method,
+       cmp-method,
+       input-builtin,
+       round-builtin,
+       intern-builtin,
+       unichr-builtin,
+       map-builtin-not-iterating,
+       zip-builtin-not-iterating,
+       range-builtin-not-iterating,
+       filter-builtin-not-iterating,
+       using-cmp-argument,
+       eq-without-hash,
+       div-method,
+       idiv-method,
+       rdiv-method,
+       exception-message-attribute,
+       invalid-str-codec,
+       sys-max-int,
+       bad-python3-import,
+       deprecated-string-function,
+       deprecated-str-translate-call,
+       deprecated-itertools-function,
+       deprecated-types-field,
+       next-method-defined,
+       dict-items-not-iterating,
+       dict-keys-not-iterating,
+       dict-values-not-iterating,
+       deprecated-operator-function,
+       deprecated-urllib-function,
+       xreadlines-attribute,
+       deprecated-sys-function,
+       exception-escape,
+       comprehension-escape
 
 
-enable=python3
+[REPORTS]
 
-[BASIC]
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=apply,input
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
 
-# Regular expression which should only match correct module names
-module-rgx=(([a-z_][a-z0-9-_]*)|([A-Z][a-zA-Z0-9]+))$
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
 
-# Regular expression which should only match correct module level names
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|_log)$
+# Tells whether to display a full report or only the messages
+reports=no
 
-# Regular expression which should only match correct class names
-class-rgx=[A-Z_][a-zA-Z0-9]+$
+# Activate the evaluation score.
+score=yes
 
-# Regular expression which should only match correct function names
-function-rgx=[a-z_][a-z0-9_]{2,50}$
 
-# Regular expression which should only match correct method names
-method-rgx=[a-z_][a-z0-9_]{2,50}$
+[REFACTORING]
 
-# Regular expression which should only match correct instance attribute names
-attr-rgx=[a-z_][a-z0-9_]{0,50}$
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
 
-# Regular expression which should only match correct argument names
-argument-rgx=[a-z_][a-z0-9_]{0,50}$
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
 
-# Regular expression which should only match correct variable names
-variable-rgx=[a-z_][a-z0-9_]{0,50}$
 
-# Regular expression which should only match correct attribute names in class
-# bodies
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,50}|(__.*__))$
+[LOGGING]
 
-# Regular expression which should only match correct list comprehension /
-# generator expression variable names
-inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
 
-# Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
 
-# Bad variable names which should always be refused, separated by a comma
-bad-names=foo,bar,baz,toto,tutu,tata
+[SPELLING]
 
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx=__.*__
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
 
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=-1
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
 
 
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX
-
-
-[VARIABLES]
-
-# Tells whether we should check for unused import in __init__ files.
-init-import=no
-
-# A regular expression matching the beginning of the name of dummy variables
-# (i.e. not used).
-dummy-variables-rgx=_$|dummy
-
-# List of additional names supposed to be defined in builtins. Remember that
-# you should avoid to define new builtins when possible.
-additional-builtins=
+notes=FIXME,
+      XXX
 
 
 [TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,
+                  acl_users,
+                  aq_parent
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).
 ignore-mixin-members=yes
 
-# List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamically set).
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
 ignored-classes=SQLObject
 
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E0201 when accessed. Python regular
-# expressions are accepted.
-generated-members=REQUEST,acl_users,aq_parent
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,io
 
 
 [FORMAT]
 
-# Maximum number of characters on a single line.
-max-line-length=120
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
-# tab).
-indent-string='    '
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+argument-rgx=[a-z_][a-z0-9_]{0,50}$
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+attr-rgx=[a-z_][a-z0-9_]{0,50}$
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,50}|(__.*__))$
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|_log)$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+function-rgx=[a-z_][a-z0-9_]{2,50}$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+method-rgx=[a-z_][a-z0-9_]{2,50}$
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+module-rgx=(([a-z_][a-z0-9-_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+variable-rgx=[a-z_][a-z0-9_]{0,50}$
 
 
 [IMPORTS]
 
-# Deprecated modules which should not be used, separated by a comma
-deprecated-modules=regsub,TERMIOS,Bastion,rexec
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
 
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled)
-import-graph=
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
 
 # Create a graph of external dependencies in the given file (report RP0402 must
 # not be disabled)
 ext-import-graph=
 
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
 # Create a graph of internal dependencies in the given file (report RP0402 must
 # not be disabled)
 int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
 
 
 [DESIGN]
@@ -154,33 +530,32 @@ int-import-graph=
 # Maximum number of arguments for function / method
 max-args=10
 
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore
-ignored-argument-names=_.*
+# Maximum number of attributes for a class (see R0902).
+max-attributes=14
 
-# Maximum number of locals for function / method body
-max-locals=16
-
-# Maximum number of return / yield for function / method body
-max-returns=6
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
 
 # Maximum number of branch for function / method body
 max-branches=12
 
-# Maximum number of statements in function / method body
-max-statements=50
+# Maximum number of locals for function / method body
+max-locals=16
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7
 
-# Maximum number of attributes for a class (see R0902).
-max-attributes=14
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=0
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods=20
 
 
 [EXCEPTIONS]

--- a/raijin_scripts/execute_ingest/run
+++ b/raijin_scripts/execute_ingest/run
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -eu
+
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case ${key} in
+        --year )                shift
+                                YEAR=$1
+                                ;;
+        --product )             shift
+                                PRODUCT=$1
+                                ;;
+        --dea-module )          shift
+                                DEA_MODULE=$1
+                                ;;
+        --queue )               shift
+                                QUEUE=$1
+                                ;;
+        --project )             shift
+                                PROJECT=$1
+                                ;;
+        * )                     exit 1
+    esac
+    shift
+done
+
+
+echo Executing ingest for "${YEAR}" "${PRODUCT}"
+echo Loading module "${DEA_MODULE}"
+
+module use /g/data/v10/public/modules/modulefiles
+
+module load "${DEA_MODULE}"
+
+
+SUBMISSION_LOG=/g/data/v10/work/ingest/ingest-submission-${PRODUCT}-`date '+%F-%T'`.log
+JOB_NAME=${YEAR}_${PRODUCT}
+
+echo Logging job: ${JOB_NAME} into: ${SUBMISSION_LOG}
+
+# Launch the submission in the background, outputting results to a log file
+nohup $SHELL > $SUBMISSION_LOG 2>&1 <<EOF &
+yes Y | dea-submit-ingest qsub --project "${PROJECT}" --queue "${QUEUE}" -n 5 -t 10 --name ${JOB_NAME} ${PRODUCT} "${YEAR}"
+EOF

--- a/raijin_scripts/execute_ingest/run
+++ b/raijin_scripts/execute_ingest/run
@@ -35,12 +35,12 @@ module use /g/data/v10/public/modules/modulefiles
 module load "${DEA_MODULE}"
 
 
-SUBMISSION_LOG=/g/data/v10/work/ingest/ingest-submission-${PRODUCT}-`date '+%F-%T'`.log
-JOB_NAME=${YEAR}_${PRODUCT}
+SUBMISSION_LOG=/g/data/v10/work/ingest/ingest-submission-${PRODUCT}-$(date '+%F-%T').log
+JOB_NAME="${YEAR}_${PRODUCT}"
 
-echo Logging job: ${JOB_NAME} into: ${SUBMISSION_LOG}
+echo "Logging job: ${JOB_NAME} into: ${SUBMISSION_LOG}"
 
 # Launch the submission in the background, outputting results to a log file
-nohup $SHELL > $SUBMISSION_LOG 2>&1 <<EOF &
-yes Y | dea-submit-ingest qsub --project "${PROJECT}" --queue "${QUEUE}" -n 5 -t 10 --name ${JOB_NAME} ${PRODUCT} "${YEAR}"
+nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 <<EOF &
+yes Y | dea-submit-ingest qsub --project "${PROJECT}" --queue "${QUEUE}" -n 5 -t 10 --name "${JOB_NAME}" "${PRODUCT}" "${YEAR}"
 EOF

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -15,7 +15,7 @@ pycodestyle "${LINT_ARGS[@]}"
 #pylint -j 2 --reports no "${LINT_ARGS[@]}"
 
 # Finds shell scripts based on #!
-find . -type f -exec file {} \; | grep "Bourne-Again shell" | cut -d: -f1 | xargs -n 1 shellcheck -e SC1071,SC1090,SC1091
+find scripts raijin_scripts -type f -exec file {} \; | grep "Bourne-Again shell" | cut -d: -f1 | xargs -n 1 shellcheck -e SC1071,SC1090,SC1091
 
 # Run tests, taking coverage.
 # Users can specify extra folders as arguments.

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -4,7 +4,7 @@
 set -eu
 set -x
 {
-    LINT_ARGS=(lambda_modules/*/* $(find raijin_scripts/ lambda_functions/ -iname '*.py'))
+    LINT_ARGS=(lambda_modules/*/* $(find raijin_scripts lambda_functions ! -path '*node_modules*' -name '*.py'))
 } &> /dev/null
 
 export PYTHONPATH=$PWD/lambda_modules/dea_es:$PWD/lambda_modules/dea_raijin${PYTHONPATH:+:${PYTHONPATH}}
@@ -12,7 +12,7 @@ export PYTHONPATH=$PWD/lambda_modules/dea_es:$PWD/lambda_modules/dea_raijin${PYT
 # Python linting
 pycodestyle "${LINT_ARGS[@]}"
 
-pylint -j 2 --reports no "${LINT_ARGS[@]}"
+#pylint -j 2 --reports no "${LINT_ARGS[@]}"
 
 # Finds shell scripts based on #!
 find . -type f -exec file {} \; | grep "Bourne-Again shell" | cut -d: -f1 | xargs -n 1 shellcheck -e SC1071,SC1090,SC1091


### PR DESCRIPTION
I've never been satisfied with the story for developing new lambdas and deploying them.

This PR takes a new approach, and uses Javascript code and the Serverless framework.
- This means the entire function fits in one simple file. (Could be simpler if my JS foo was stronger)
- Can be easily and repeatedly deployed with `sls deploy`
- The configuration for scheduling and IAM permissions is all contained within the `serverless.yml`.
- It should be able to be easily extended to support most of our NCI automation tasks with minimal code expansion.