### PR TITLE
Add timeout to the serverless.yml

### DIFF
--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -28,6 +28,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs6.10
+  timeout: 300 # 5 minutes (max). Default is 6 seconds
   environment:
     hostkey: 'orchestrator.raijin.users.default.host'
     userkey: 'orchestrator.raijin.users.default.user'


### PR DESCRIPTION
Update timeout value to be 5 mins (max) from default timeout of 6 seconds. This is done to avoid re-execution of the lambda function.