### PR TITLE
Simplify sed expression and remove ls5 fc

### DIFF
--- a/raijin_scripts/test_deaenv_fc/dea_testscripts/copy_fcyaml_files.sh
+++ b/raijin_scripts/test_deaenv_fc/dea_testscripts/copy_fcyaml_files.sh
@@ -21,5 +21,5 @@ do
   yaml_filename=$(basename "$FC_CONF_DIR")
 
   wget -q "$FC_CONF_DIR"
-  sed -e 's,location: .*,location: "'"$WORKDIR"'/work",' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
+  sed -i -e 's,location: .*,location: "'"$WORKDIR"'/work",' "$yaml_filename"
 done

--- a/raijin_scripts/test_deaenv_fc/run
+++ b/raijin_scripts/test_deaenv_fc/run
@@ -67,8 +67,4 @@ echo "Applying fractional cover on ls8_fc_albers product for the year ${YEAR}" w
 echo "------------------------------------------------------------------------------------------"
 datacube-fc submit --app-config "$WORKDIR"/fc_configfiles/ls8_fc_albers.yaml --project "${PROJECT}" --queue "${QUEUE}" -C "$DC_CONFIG_FILEPATH" -vvv --year "${YEAR}" --tag "${TAG}"
 
-echo "Applying fractional cover on ls5_fc_albers product for the year ${YEAR}" with tag "${TAG}"
-echo "------------------------------------------------------------------------------------------"
-datacube-fc submit --app-config "$WORKDIR"/fc_configfiles/ls5_fc_albers.yaml --project "${PROJECT}" --queue "${QUEUE}" -C "$DC_CONFIG_FILEPATH" -vvv --year "${YEAR}" --tag "${TAG}"
-
 EOF

--- a/raijin_scripts/test_deaenv_ingest/dea_testscripts/cp_indingest_yaml_files.sh
+++ b/raijin_scripts/test_deaenv_ingest/dea_testscripts/cp_indingest_yaml_files.sh
@@ -24,6 +24,6 @@ do
   yaml_filename=$(basename "$INGEST_CONF_DIR")
 
   wget -q "$INGEST_CONF_DIR"
-  sed -e 's,location: .*,location: "'"$WORKDIR"'/work",' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,description:,metadata_type: eo'"\\n\\"'description:,'  "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
+  sed -i -e 's,location: .*,location: "'"$WORKDIR"'/work",' "$yaml_filename"
+  sed -i -e 's,description:,metadata_type: eo'"\\n\\"'description:,'  "$yaml_filename"
 done

--- a/raijin_scripts/test_deaenv_stats/dea_testscripts/cp_statsyaml_files.sh
+++ b/raijin_scripts/test_deaenv_stats/dea_testscripts/cp_statsyaml_files.sh
@@ -26,11 +26,11 @@ do
   yaml_filename=$(basename "$FC_STATS_CONF_DIR")
 
   wget -q "$FC_STATS_CONF_DIR"
-  sed -e 's,location: .*,location: "'"$WORKDIR"'/fc_stats/001",' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,2018-01-01,2019-01-01,' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,  start_date: .*,  start_date: 2018-01-01,' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,  end_date: .*,  end_date: 2019-01-01,' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,2017-01-01,2019-01-01,' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
+  sed -i -e 's,location: .*,location: "'"$WORKDIR"'/fc_stats/001",' "$yaml_filename"
+  sed -i -e 's,2018-01-01,2019-01-01,' "$yaml_filename"
+  sed -i -e 's,  start_date: .*,  start_date: 2018-01-01,' "$yaml_filename"
+  sed -i -e 's,  end_date: .*,  end_date: 2019-01-01,' "$yaml_filename"
+  sed -i -e 's,2017-01-01,2019-01-01,' "$yaml_filename"
 done
 
 for i in "${fcpercentiltstats_yaml_array[@]}"
@@ -39,11 +39,11 @@ do
   yaml_filename=$(basename "$FC_STATS_CONF_DIR")
 
   wget -q "$FC_STATS_CONF_DIR"
-  sed -e 's,location: .*,location: "'"$WORKDIR"'/fc_stats/001",' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,2018-01-01,2019-01-01,' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,  start_date: .*,  start_date: 2018-01-01,' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,  end_date: .*,  end_date: 2019-01-01\n  stats_duration: 3m\n  step_size: 3m,' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,2017-01-01,2019-01-01,' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
+  sed -i -e 's,location: .*,location: "'"$WORKDIR"'/fc_stats/001",' "$yaml_filename"
+  sed -i -e 's,2018-01-01,2019-01-01,' "$yaml_filename"
+  sed -i -e 's,  start_date: .*,  start_date: 2018-01-01,' "$yaml_filename"
+  sed -i -e 's,  end_date: .*,  end_date: 2019-01-01\n  stats_duration: 3m\n  step_size: 3m,' "$yaml_filename"
+  sed -i -e 's,2017-01-01,2019-01-01,' "$yaml_filename"
 done
 
 # Replace NBAR stats product output location in the yaml file
@@ -54,9 +54,9 @@ do
   yaml_filename=$(basename "$NBAR_STATS_CONF_DIR")
 
   wget -q "$NBAR_STATS_CONF_DIR"
-  sed -e 's,location: .*,location: "'"$WORKDIR"'/nbar_stats/001",' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,  start_date: .*,  start_date: 2018-01-01,' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
-  sed -e 's,  end_date: .*,  end_date: 2019-01-01,' "$yaml_filename" > "$yaml_filename.tmp" && mv "$yaml_filename.tmp" "$yaml_filename"
+  sed -i -e 's,location: .*,location: "'"$WORKDIR"'/nbar_stats/001",' "$yaml_filename"
+  sed -i -e 's,  start_date: .*,  start_date: 2018-01-01,' "$yaml_filename"
+  sed -i -e 's,  end_date: .*,  end_date: 2019-01-01,' "$yaml_filename"
 done
 
 cp "$2"/dea_testscripts/landsat_seasonal_mean.yaml "$WORKDIR"/stats_configfiles


### PR DESCRIPTION
Following are the changes in this PR:
1) Simplify sed expression to include 'sed -i -e' to modify in-place file we are sed-ing.
2) Remove ls5 fractional cover from the raijin script.