### PR TITLE
Increase ingest/sync walltime and add deploy section to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ script:
 deploy:
    provider: script
    script:
-     - if [ "$TRAVIS_PULL_REQUEST" != "false" ]
+     # Serverless deploy to production environment after merging to production branch
+     - if [ "$TRAVIS_PULL_REQUEST" == "false" ]
        then
           cd lambda_functions/execute_ssh_command_js/
           npm install -g npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ deploy:
      - if [ "$TRAVIS_PULL_REQUEST" == "false" ]
        then
           cd lambda_functions/execute_ssh_command_js/
-          npm install -g npm
           npm install
           sls deploy -v -s prod
        else

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,18 @@ script:
   - ./scripts/check-code.sh
 
 
-#deploy:
-# - provider: script
-#   script: scripts/aws-lambda-deploy.js hello-world production
-#   skip_cleanup: true
-#   on:
-#     branch: master
+deploy:
+   provider: script
+   script:
+     - if [ "$TRAVIS_PULL_REQUEST" != "false" ]
+       then
+          cd lambda_functions/execute_ssh_command_js/
+          npm install -g npm
+          npm install
+          sls deploy -v -s prod
+       else
+          echo "Skip deploy"
+       fi
+   skip_cleanup: true
+   on:
+     branch: production

--- a/lambda_functions/execute_ssh_command_js/README.md
+++ b/lambda_functions/execute_ssh_command_js/README.md
@@ -70,6 +70,7 @@ In order to deploy the endpoint, simply run:
 
 In order to run the script (before an event is triggered), simply run:
 
-     1) `sls invoke -f execute_sync -l -s prod -d '{"year": "2018", "product": "ls8_nbart_scene", "dea-module": "dea/20180801", "project":"v10", "queue":"express", "stage": "prod", "trasharchived": "no", "path": "/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbart/"}'`
+     1) `sls invoke -f git_pull_prod -l -s prod`
+     2) `sls invoke -f execute_sync -l -s prod -d '{"year": "2018", "product": "ls8_nbart_scene", "dea-module": "dea/20180801", "project":"v10", "queue":"express", "stage": "prod", "trasharchived": "no", "path": "/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbart/"}'`
      
      Note: Use appropriate stage (-s dev or -s prod) when using sls invoke

--- a/lambda_functions/execute_ssh_command_js/README.md
+++ b/lambda_functions/execute_ssh_command_js/README.md
@@ -70,6 +70,6 @@ In order to deploy the endpoint, simply run:
 
 In order to run the script (before an event is triggered), simply run:
 
-     1) `serverless invoke -f execute_ingest -l -d '{"command": "execute_ingest", "year": "2017", "product": "ls8_nbar_albers", "dea-module": "dea/20180515", "project":"u46", "queue":"express"}'`
+     1) `sls invoke -f execute_sync -l -s prod -d '{"year": "2018", "product": "ls8_nbart_scene", "dea-module": "dea/20180801", "project":"v10", "queue":"express", "stage": "prod", "trasharchived": "no", "path": "/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbart/"}'`
      
      Note: Use appropriate stage (-s dev or -s prod) when using sls invoke

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -37,14 +37,14 @@ provider:
     hostkey: 'orchestrator.raijin.users.default.host'
     userkey: 'orchestrator.raijin.users.default.user'
     pkey: 'orchestrator.raijin.users.default.pkey'
-    DEA_MODULE: dea/20180705
+    DEA_MODULE: dea/20180801
     PROJECT: v10
-    QUEUE: express
+    QUEUE: normal
   region: ap-southeast-2
   deploymentBucket: ${self:custom.CustEnv.s3Bucket.${self:custom.Stage}}
   stackTags:
     repo: dea-orchestration
-    author: santosh.mohan@ga.gov.au
+    author: nci.monitor@dea.ga.gov.au
     purpose: nci-automation
 # you can add statements to the Lambda function's IAM Role here
   iamRoleStatements:
@@ -75,7 +75,7 @@ functions:
                          --trasharchived <%= trasharchived %>'
     events:
       - schedule:
-          rate: cron(10 08 ? * TUE *) # Run every Tuesday, at 08:10:00 am UTC time
+          rate: cron(10 00 ? * TUE *) # Run every Tuesday, at 00:10:00 am UTC time
           enabled: false
           input:
             year: 2018
@@ -83,7 +83,7 @@ functions:
             path: '/g/data/v10/reprocess/ls8/level1/2018/'
             trasharchived: no
       - schedule:
-          rate: cron(10 09 ? * TUE *) # Run every Tuesday, at 09:10:00 am UTC time
+          rate: cron(10 01 ? * TUE *) # Run every Tuesday, at 01:10:00 am UTC time
           enabled: false
           input:
             year: 2018
@@ -91,7 +91,63 @@ functions:
             path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/01/output/nbart/'
             trasharchived: no
       - schedule:
-          rate: cron(10 10 ? * TUE *) # Run every Tuesday, at 10:10:00 am UTC time
+          rate: cron(10 02 ? * TUE *) # Run every Tuesday, at 02:10:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/02/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 03 ? * TUE *) # Run every Tuesday, at 03:10:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/03/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 04 ? * TUE *) # Run every Tuesday, at 04:10:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/04/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 05 ? * TUE *) # Run every Tuesday, at 05:10:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 06 ? * TUE *) # Run every Tuesday, at 06:10:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/06/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 07 ? * TUE *) # Run every Tuesday, at 07:10:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 08 ? * TUE *) # Run every Tuesday, at 08:10:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/01/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 09 ? * TUE *) # Run every Tuesday, at 09:10:00 am UTC time
           enabled: false
           input:
             year: 2018
@@ -99,7 +155,47 @@ functions:
             path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/02/output/nbar/'
             trasharchived: no
       - schedule:
-          rate: cron(10 19 ? * TUE *) # Run every Tuesday, at 19:10:00 pm UTC time
+          rate: cron(10 10 ? * TUE *) # Run every Tuesday, at 10:10:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/03/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 11 ? * TUE *) # Run every Tuesday, at 11:10:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/04/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 12 ? * TUE *) # Run every Tuesday, at 12:10:00 pm UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 13 ? * TUE *) # Run every Tuesday, at 13:10:00 pm UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/06/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 14 ? * TUE *) # Run every Tuesday, at 14:10:00 pm UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(10 15 ? * TUE *) # Run every Tuesday, at 15:10:00 pm UTC time
           enabled: false
           input:
             year: 2018
@@ -107,7 +203,7 @@ functions:
             path: '/g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/'
             trasharchived: no
       - schedule:
-          rate: cron(10 20 ? * TUE *) # Run every Tuesday, at 20:10:00 pm UTC time
+          rate: cron(10 16 ? * TUE *) # Run every Tuesday, at 16:10:00 pm UTC time
           enabled: false
           input:
             year: 2018
@@ -122,7 +218,7 @@ functions:
       pkey: 'orchestrator.raijin.users.git_pull.pkey'
     events:
       - schedule:
-          rate: cron(00 08 ? * TUE *) # Run every Tuesday, at 08:00:00 am UTC time
+          rate: cron(02 00 ? * TUE *) # Run every Tuesday, at 00:02:00 am UTC time
           enabled: true
   execute_ingest:
     handler: handler.execute_ssh_command
@@ -135,41 +231,23 @@ functions:
                            --product <%= product %>'
     events:
       - schedule:
-          rate: cron(00 09 ? * FRI *) # Run every Friday, at 09:00:00 am UTC time
+          rate: cron(10 00 ? * WED *) # Run every Wednesday, at 00:10:00 am UTC time
           enabled: false
           input:
             year: 2018
             product: ls8_nbar_albers
       - schedule:
-          rate: cron(00 15 ? * FRI *) # Run every Friday, at 03:00:00 pm UTC time
+          rate: cron(10 03 ? * WED *) # Run every Wednesday, at 03:10:00 am UTC time
           enabled: false
           input:
             year: 2018
             product: ls8_nbart_albers
       - schedule:
-          rate: cron(00 21 ? * FRI *) # Run every Friday, at 09:00:00 pm UTC time
+          rate: cron(10 06 ? * WED *) # Run every Wednesday, at 06:10:00 am UTC time
           enabled: false
           input:
             year: 2018
             product: ls8_pq_albers
-      - schedule:
-          rate: cron(00 03 ? * SAT *) # Run every Saturday, at 03:00:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_oli_albers
-      - schedule:
-          rate: cron(00 09 ? * SAT *) # Run every Saturday, at 09:00:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_oli_albers
-      - schedule:
-          rate: cron(00 15 ? * SAT *) # Run every Saturday, at 03:00:00 pm UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_pq_oli_albers
   execute_stacker:
     handler: handler.execute_ssh_command
     environment:
@@ -197,24 +275,6 @@ functions:
           input:
             year: 2018
             appconfig: ls8_pq_albers.yaml
-      - schedule:
-          rate: cron(15 05 * * ? *) # Run daily, at 05:15:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            appconfig: ls8_nbar_oli_albers.yaml
-      - schedule:
-          rate: cron(30 05 * * ? *) # Run daily, at 05:30:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            appconfig: ls8_nbart_oli_albers.yaml
-      - schedule:
-          rate: cron(45 05 * * ? *) # Run daily, at 05:45:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            appconfig: ls8_pq_oli_albers.yaml
   execute_clean:
     handler: handler.execute_ssh_command
     environment:

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -61,6 +61,16 @@ provider:
         - "arn:aws:kms:#{AWS::Region}:#{AWS::AccountId}:key/*"
 
 functions:
+  git_pull_prod:
+    handler: handler.execute_ssh_command
+    environment:
+      hostkey: 'orchestrator.raijin.users.git_pull.host'
+      userkey: 'orchestrator.raijin.users.git_pull.user'
+      pkey: 'orchestrator.raijin.users.git_pull.pkey'
+    events:
+      - schedule:
+          rate: cron(02 08 ? * THU *) # Run every Thursday, at 08:02:00 am UTC time
+          enabled: false
   execute_sync:
     # trasharchived is set to 'yes' only for the albers products and not for the scenes
     handler: handler.execute_ssh_command
@@ -75,127 +85,7 @@ functions:
                          --trasharchived <%= trasharchived %>'
     events:
       - schedule:
-          rate: cron(10 00 ? * TUE *) # Run every Tuesday, at 00:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_level1_scene
-            path: '/g/data/v10/reprocess/ls8/level1/2018/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 01 ? * TUE *) # Run every Tuesday, at 01:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/01/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 02 ? * TUE *) # Run every Tuesday, at 02:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/02/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 03 ? * TUE *) # Run every Tuesday, at 03:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/03/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 04 ? * TUE *) # Run every Tuesday, at 04:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/04/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 05 ? * TUE *) # Run every Tuesday, at 05:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 06 ? * TUE *) # Run every Tuesday, at 06:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/06/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 07 ? * TUE *) # Run every Tuesday, at 07:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 08 ? * TUE *) # Run every Tuesday, at 08:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/01/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 09 ? * TUE *) # Run every Tuesday, at 09:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/02/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 10 ? * TUE *) # Run every Tuesday, at 10:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/03/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 11 ? * TUE *) # Run every Tuesday, at 11:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/04/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 12 ? * TUE *) # Run every Tuesday, at 12:10:00 pm UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 13 ? * TUE *) # Run every Tuesday, at 13:10:00 pm UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/06/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 14 ? * TUE *) # Run every Tuesday, at 14:10:00 pm UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 15 ? * TUE *) # Run every Tuesday, at 15:10:00 pm UTC time
+          rate: cron(10 08 ? * THU *) # Run every Thursday, at 08:10:00 am UTC time
           enabled: false
           input:
             year: 2018
@@ -203,23 +93,133 @@ functions:
             path: '/g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/'
             trasharchived: no
       - schedule:
-          rate: cron(10 16 ? * TUE *) # Run every Tuesday, at 16:10:00 pm UTC time
+          rate: cron(15 08 ? * THU *) # Run every Thursday, at 08:15:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_level1_scene
+            path: '/g/data/v10/reprocess/ls8/level1/2018/'
+            trasharchived: no
+      - schedule:
+          rate: cron(16 08 ? * THU *) # Run every Thursday, at 08:16:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/01/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(17 08 ? * THU *) # Run every Thursday, at 08:17:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/02/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(18 08 ? * THU *) # Run every Thursday, at 08:18:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/03/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(19 08 ? * THU *) # Run every Thursday, at 08:19:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/04/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(20 08 ? * THU *) # Run every Thursday, at 08:20:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(21 08 ? * THU *) # Run every Thursday, at 08:21:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/06/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(22 08 ? * THU *) # Run every Thursday, at 08:22:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(23 08 ? * THU *) # Run every Thursday, at 08:23:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/01/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(24 08 ? * THU *) # Run every Thursday, at 08:24:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/02/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(25 08 ? * THU *) # Run every Thursday, at 08:25:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/03/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(26 08 ? * THU *) # Run every Thursday, at 08:26:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/04/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(27 08 ? * THU *) # Run every Thursday, at 08:27:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(28 08 ? * THU *) # Run every Thursday, at 08:28:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/06/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(29 08 ? * THU *) # Run every Thursday, at 08:29:00 am UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbar/'
+            trasharchived: no
+      - schedule:
+          rate: cron(30 08 ? * THU *) # Run every Thursday, at 08:30:00 am UTC time
           enabled: false
           input:
             year: 2018
             product: ls8_pq_legacy_scene
             path: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls8/2018/'
             trasharchived: no
-  git_pull_prod:
-    handler: handler.execute_ssh_command
-    environment:
-      hostkey: 'orchestrator.raijin.users.git_pull.host'
-      userkey: 'orchestrator.raijin.users.git_pull.user'
-      pkey: 'orchestrator.raijin.users.git_pull.pkey'
-    events:
-      - schedule:
-          rate: cron(02 00 ? * TUE *) # Run every Tuesday, at 00:02:00 am UTC time
-          enabled: true
   execute_ingest:
     handler: handler.execute_ssh_command
     environment:
@@ -231,19 +231,19 @@ functions:
                            --product <%= product %>'
     events:
       - schedule:
-          rate: cron(10 00 ? * WED *) # Run every Wednesday, at 00:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_albers
-      - schedule:
-          rate: cron(10 03 ? * WED *) # Run every Wednesday, at 03:10:00 am UTC time
+          rate: cron(00 17 ? * THU *) # Run every Thursday, at 17:00:00 pm UTC time
           enabled: false
           input:
             year: 2018
             product: ls8_nbart_albers
       - schedule:
-          rate: cron(10 06 ? * WED *) # Run every Wednesday, at 06:10:00 am UTC time
+          rate: cron(10 17 ? * THU *) # Run every Thursday, at 17:10:00 pm UTC time
+          enabled: false
+          input:
+            year: 2018
+            product: ls8_nbar_albers
+      - schedule:
+          rate: cron(45 11 ? * FRI *) # Run every Friday, at 11:45:00 am UTC time
           enabled: false
           input:
             year: 2018

--- a/raijin_scripts/execute_ingest/run
+++ b/raijin_scripts/execute_ingest/run
@@ -91,5 +91,5 @@ echo "Executing ingest for ${YEAR} ${PRODUCT}"
 ##################################################################################################
 # Run dea-submit-ingest process
 ##################################################################################################
-yes Y | dea-submit-ingest qsub --project "${PROJECT}" --queue "${QUEUE}" -n 5 -t 10 --name "${JOB_NAME}" "${PRODUCT}" "${YEAR}"
+yes Y | dea-submit-ingest qsub --project "${PROJECT}" --queue "${QUEUE}" -n 5 -t 40 --name "${JOB_NAME}" "${PRODUCT}" "${YEAR}"
 EOF

--- a/raijin_scripts/execute_ingest/run
+++ b/raijin_scripts/execute_ingest/run
@@ -91,5 +91,5 @@ echo "Executing ingest for ${YEAR} ${PRODUCT}"
 ##################################################################################################
 # Run dea-submit-ingest process
 ##################################################################################################
-yes Y | dea-submit-ingest qsub --project "${PROJECT}" --queue "${QUEUE}" -n 5 -t 40 --name "${JOB_NAME}" "${PRODUCT}" "${YEAR}"
+yes Y | dea-submit-ingest qsub --project "${PROJECT}" --queue "${QUEUE}" -n 5 -t 10 --allow-product-changes --name "${JOB_NAME}" "${PRODUCT}" "${YEAR}"
 EOF

--- a/raijin_scripts/execute_sync/run
+++ b/raijin_scripts/execute_sync/run
@@ -102,5 +102,5 @@ echo "Starting Sync process......"
 ##################################################################################################
 # Run dea-sync process
 ##################################################################################################
-qsub -V -N dea-sync -q "${QUEUE}" -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" -o "$WORKDIR" -e "$WORKDIR" -- dea-sync -vvv --cache-folder "$WORKDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing "$PATH_TO_PROCESS"
+qsub -V -N dea-sync -q "${QUEUE}" -W umask=33 -l wd,walltime=20:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" -o "$WORKDIR" -e "$WORKDIR" -- dea-sync -vvv --cache-folder "$WORKDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing "$PATH_TO_PROCESS"
 EOF

--- a/raijin_scripts/execute_sync/run
+++ b/raijin_scripts/execute_sync/run
@@ -102,5 +102,5 @@ echo "Starting Sync process......"
 ##################################################################################################
 # Run dea-sync process
 ##################################################################################################
-qsub -V -N dea-sync -q "${QUEUE}" -W umask=33 -l wd,walltime=20:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" -o "$WORKDIR" -e "$WORKDIR" -- dea-sync -vvv --cache-folder "$WORKDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing "$PATH_TO_PROCESS"
+qsub -V -N dea-sync -q "${QUEUE}" -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" -o "$WORKDIR" -e "$WORKDIR" -- dea-sync -vvv --cache-folder "$WORKDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing "$PATH_TO_PROCESS"
 EOF


### PR DESCRIPTION
**Reason for this pull request**
During testing ingest process, it was noticed that a wall-time of 10 hours was not be sufficient for 2018. Due to this limitation, pbs scheduler was terminating the execution.

**Proposed solution:**
- Increase the wall-time to 40hrs for ingest process and 20hrs for sync process.
- Make the job queue as "normal" instead of "express" to allow increased wall-time.
- Update serverless.yml file to use latest dea module and do lambda scheduling cleanup.
- Update travis file to include deploy section