### PR TITLE
Redirect fc output submission log to work directory

### DIFF
--- a/raijin_scripts/execute_fractional_cover/run
+++ b/raijin_scripts/execute_fractional_cover/run
@@ -30,7 +30,7 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-LOG_FILENAME=fc-submission-${PRODUCT}-$(date '+%F-%T').log
+LOG_FILENAME="${PRODUCT}"-submission-$(date '+%F-%T').log
 SUBMISSION_LOG=/g/data/v10/work/fc/"$LOG_FILENAME"
 JOB_NAME="${YEAR}_${PRODUCT}"
 count=0

--- a/raijin_scripts/execute_fractional_cover/run
+++ b/raijin_scripts/execute_fractional_cover/run
@@ -30,15 +30,14 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-WORKDIR=/g/data/v10/work/fc/"${PRODUCT}"/$(date '+%FT%H%M')
-SUBMISSION_LOG="${WORKDIR}"/fc-submission-${PRODUCT}-$(date '+%F-%T').log
+LOG_FILENAME=fc-submission-${PRODUCT}-$(date '+%F-%T').log
+SUBMISSION_LOG=/g/data/v10/work/fc/"$LOG_FILENAME"
 JOB_NAME="${YEAR}_${PRODUCT}"
 count=0
 dbhostname='agdcdev-db.nci.org.au'
 dbport='6432'
 dbname='datacube'
 
-mkdir -p "${WORKDIR}"
 echo "Start time: " "$(date '+%F-%T')" > "$SUBMISSION_LOG"
 
 module use /g/data/v10/public/modules/modulefiles
@@ -71,8 +70,6 @@ cd /g/data/v10/work/fc/
 APP_CONFIG=$(datacube-fc list | grep "${PRODUCT}")
 
 # Launch the submission in the background, outputting results to a log file
-cd "${WORKDIR}"
-
 nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 <<EOF &
 echo "Logging job: ${JOB_NAME} into: ${SUBMISSION_LOG}"
 echo ""
@@ -99,3 +96,8 @@ echo "Executing fractional cover for ${YEAR} ${PRODUCT} with tag ${TAG}"
 ##################################################################################################
 datacube-fc submit -v -v --project "${PROJECT}" --queue "${QUEUE}" --year "${YEAR}" --app-config "${APP_CONFIG}" --tag "${TAG}"
 EOF
+
+# Move submission log file to fc work directory
+searchstring='Created work directory '
+dirpath=$(sed "s:.*$searchstring/::" <<< "$(grep "$searchstring" "$SUBMISSION_LOG")")
+if [[ -d /"$dirpath" && -f "$SUBMISSION_LOG" ]]; then cp -p -r "$SUBMISSION_LOG" /"$dirpath/$LOG_FILENAME" && rm -rf "$SUBMISSION_LOG"; fi

--- a/raijin_scripts/execute_fractional_cover/run
+++ b/raijin_scripts/execute_fractional_cover/run
@@ -92,7 +92,7 @@ echo "**********************************************************************"
 echo ""
 echo "Executing fractional cover for ${YEAR} ${PRODUCT} with tag ${TAG}"
 ##################################################################################################
-# Run dea-submit-fractional cover process
+# Run fractional cover two stage process
 ##################################################################################################
 datacube-fc submit -v -v --project "${PROJECT}" --queue "${QUEUE}" --year "${YEAR}" --app-config "${APP_CONFIG}" --tag "${TAG}"
 EOF

--- a/raijin_scripts/execute_fractional_cover/run
+++ b/raijin_scripts/execute_fractional_cover/run
@@ -92,11 +92,12 @@ echo "**********************************************************************"
 echo ""
 echo "Executing fractional cover for ${YEAR} ${PRODUCT} with tag ${TAG}"
 ##################################################################################################
-# Run fractional cover two stage process
+# Run datacube-fc submit two stage PBS job
 ##################################################################################################
 datacube-fc submit -v -v --project "${PROJECT}" --queue "${QUEUE}" --year "${YEAR}" --app-config "${APP_CONFIG}" --tag "${TAG}"
 EOF
 
+sleep 60s # Wait 60s before moving the submission log
 # Move submission log file to fc work directory
 searchstring='Created work directory '
 dirpath=$(sed "s:.*$searchstring/::" <<< "$(grep "$searchstring" "$SUBMISSION_LOG")")

--- a/raijin_scripts/execute_fractional_cover/run
+++ b/raijin_scripts/execute_fractional_cover/run
@@ -70,7 +70,7 @@ cd /g/data/v10/work/fc/
 APP_CONFIG=$(datacube-fc list | grep "${PRODUCT}")
 
 # Launch the submission in the background, outputting results to a log file
-nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 <<EOF &
+{
 echo "Logging job: ${JOB_NAME} into: ${SUBMISSION_LOG}"
 echo ""
 echo Loading module "${MODULE}"
@@ -95,10 +95,10 @@ echo "Executing fractional cover for ${YEAR} ${PRODUCT} with tag ${TAG}"
 # Run datacube-fc submit two stage PBS job
 ##################################################################################################
 datacube-fc submit -v -v --project "${PROJECT}" --queue "${QUEUE}" --year "${YEAR}" --app-config "${APP_CONFIG}" --tag "${TAG}"
-EOF
+} > "$SUBMISSION_LOG"
 
-sleep 60s # Wait 60s before moving the submission log
+sleep 2s
 # Move submission log file to fc work directory
 searchstring='Created work directory '
 dirpath=$(sed "s:.*$searchstring/::" <<< "$(grep "$searchstring" "$SUBMISSION_LOG")")
-if [[ -d /"$dirpath" && -f "$SUBMISSION_LOG" ]]; then cp -p -r "$SUBMISSION_LOG" /"$dirpath/$LOG_FILENAME" && rm -rf "$SUBMISSION_LOG"; fi
+if [[ -d "$dirpath" && -f "$SUBMISSION_LOG" ]]; then mv "$SUBMISSION_LOG" "$dirpath"; fi


### PR DESCRIPTION
**Reason for this pull request**
FC app redirects events_path, logs_path, jobs_path and other logs to the directory structure in the following format (different to that of sync/ingest process):
`/g/data/v10/work/{output_product}/{task_type}/`
 where,` task_type = create/sync/fc etc.`

**Proposed solution**
Move the execution submission log file to FC work directory (mentioned above) to maintain consistency within previous FC work directory structure. 