### PR TITLE
Add configuration and script for lambda submission of dea-coherence

### DIFF
--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -327,6 +327,22 @@ functions:
             year: 2018
             product: wofs_albers
             tag: '2018'
+  execute_coherence:
+    handler: handler.execute_ssh_command
+    environment:
+      cmd: 'execute_coherence --dea-module ${self:provider.environment.DEA_MODULE}
+                              --queue ${self:provider.environment.QUEUE}
+                              --project ${self:provider.environment.PROJECT}
+                              --stage ${self:custom.Stage}
+                              --timerange <%= timerange %>
+                              --product <%= product %>'
+    events:
+      - schedule:
+          rate: cron(10 08 ? * THU *) # Run every Thursday, at 08:10:00 am UTC time
+          enabled: false
+          input:
+            timerange: '2018-01-01 < time < 2018-12-31'
+            product: ls8_fc_albers
   execute_clean:
     handler: handler.execute_ssh_command
     environment:

--- a/raijin_scripts/execute_coherence/run
+++ b/raijin_scripts/execute_coherence/run
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -eu
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case ${key} in
+        --dea-module )          shift
+                                MODULE=$1
+                                ;;
+        --queue )               shift
+                                QUEUE=$1
+                                ;;
+        --project )             shift
+                                PROJECT=$1
+                                ;;
+        --stage )               shift
+                                STAGE=$1
+                                ;;
+        --timerange )           shift
+                                RANGE_EXP=$1
+                                ;;
+        --product )             shift
+                                PRODUCT=$1
+                                ;;
+        * )                     exit 0
+    esac
+    shift
+done
+
+WORKDIR=/g/data/v10/work/coherence/"${PRODUCT}"/$(date '+%FT%H%M')
+SUBMISSION_LOG="$WORKDIR"/"${PRODUCT}"-coherence-submission-$(date '+%F-%T').log
+count=0
+dbhostname='agdcdev-db.nci.org.au'
+dbport='6432'
+dbname='datacube'
+
+mkdir -p "${WORKDIR}"
+echo "Start time: " "$(date '+%F-%T')" > "$SUBMISSION_LOG"
+
+module use /g/data/v10/public/modules/modulefiles
+module load "${MODULE}"
+while read -r LINE; do
+  if [[ "$count" -eq 1 ]]
+  then
+      dbhostname="$(cut -d' ' -f2 <<<"$LINE")"
+      count=$((count+1))
+  elif [[ "$count" -eq 2 ]]
+  then
+      dbport="$(cut -d' ' -f2 <<<"$LINE")"
+      count=$((count+1))
+  elif [[ "$count" -eq 3 ]]
+  then
+      dbname="$(cut -d' ' -f2 <<<"$LINE")"
+      count=$((count+1))
+  fi
+
+  if [[ "${STAGE}" == "dev"  && "$LINE" == "[dea-dev]" ]]; then
+      count=$((count+1))
+  fi
+
+  if [[ "${STAGE}" == "prod"  && "$LINE" == "[datacube]" ]]; then
+      count=$((count+1))
+  fi
+done  < "$DATACUBE_CONFIG_PATH"
+
+cd "${WORKDIR}"
+
+nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 << EOF &
+echo "Logging into: ${SUBMISSION_LOG}"
+echo ""
+echo Loading module "${MODULE}"
+echo ""
+
+# Check if we can connect to the database
+datacube -vv system check
+
+# Read agdc datasets from the database before dea-coherence process
+echo ""
+echo "***************************************************************************"
+echo "Read previous agdc_dataset product names and count before coherence process"
+echo "Connected to the database host name: $dbhostname"
+echo "Connected to the database port number: $dbport"
+echo "Connected to the database name: $dbname"
+psql -h "${dbhostname}" -p "${dbport}"  -d "${dbname}"  -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
+echo "***************************************************************************"
+
+echo ""
+echo "Starting coherence process......"
+##################################################################################################
+# Qsub dea-coherence process
+##################################################################################################
+qsub -V -N dea-coherence -q "${QUEUE}" -W umask=33 -l wd,walltime=20:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" -o "$WORKDIR" -e "$WORKDIR" -- dea-coherence --check-ancestors --check-siblings --archive-siblings --check-locationless --archive-locationless "${RANGE_EXP}" product="${PRODUCT}"
+
+EOF


### PR DESCRIPTION
**Request for this pull request**
During ingest process, it was observed that duplicate datasets were ingested. To fix this issue, we need to use DEA-coherence tool to archive locationless datasets and sibling datasets. Need for automated coherence process by adding the configuration and raijin script to the dea-orchestration resulted in this PR.

**Proposed solution**
1) Add execute_coherence script to the raijin scripts directory.
2) Add configuration for lambda submission of `dea-coherence` to the `serverless.yml` file.

- [x] Tests added
Note: Tests were added as part of NCI environment test script