### PR TITLE
Automate lambda schedule to run Sync/Ingest/WOfS/FC at the NCI

### DIFF
--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -69,7 +69,7 @@ functions:
       pkey: 'orchestrator.raijin.users.git_pull.pkey'
     events:
       - schedule:
-          rate: cron(15 00 ? * MON,TUE,WED *) # Run every Monday-Wednesday, at 00:15:00 am UTC time
+          rate: cron(00 10 ? * WED,THU,FRI *) # Run every Wednesday-Friday, at 08:00 pm Canberra time
           enabled: true
   execute_sync:
     # trasharchived is set to 'yes' only for the albers products and not for the scenes
@@ -85,7 +85,7 @@ functions:
                          --trasharchived <%= trasharchived %>'
     events:
       - schedule:
-          rate: cron(30 00 ? * MON *) # Run every Monday, at 00:30:00 am UTC time
+          rate: cron(10 10 ? * WED *) # Run every Wednesday, at 08:10 pm Canberra time
           enabled: true
           input:
             year: 2018
@@ -93,7 +93,7 @@ functions:
             path: '/g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/'
             trasharchived: no
       - schedule:
-          rate: cron(30 00 ? * MON *) # Run every Monday, at 00:30:00 am UTC time
+          rate: cron(10 10 ? * WED *) # Run every Wednesday, at 08:10 pm Canberra time
           enabled: true
           input:
             year: 2018
@@ -101,7 +101,7 @@ functions:
             path: '/g/data/v10/reprocess/ls8/level1/2018/'
             trasharchived: no
       - schedule:
-          rate: cron(30 00 ? * MON *) # Run every Monday, at 00:30:00 am UTC time
+          rate: cron(10 10 ? * WED *) # Run every Wednesday, at 08:10 pm Canberra time
           enabled: true
           input:
             year: 2018
@@ -109,7 +109,7 @@ functions:
             path: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls8/2018/'
             trasharchived: no
       - schedule:
-          rate: cron(30 00 ? * MON *) # Run every Monday, at 00:30:00 am UTC time
+          rate: cron(10 10 ? * WED *) # Run every Wednesday, at 08:10 pm Canberra time
           enabled: true
           input:
             year: 2018
@@ -117,7 +117,7 @@ functions:
             path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/??/output/nbart/'
             trasharchived: no
       - schedule:
-          rate: cron(30 00 ? * MON *) # Run every Monday, at 00:30:00 am UTC time
+          rate: cron(10 10 ? * WED *) # Run every Wednesday, at 08:10 pm Canberra time
           enabled: true
           input:
             year: 2018
@@ -135,19 +135,19 @@ functions:
                            --product <%= product %>'
     events:
       - schedule:
-          rate: cron(15 05 ? * TUE *) # Run every Tuesday, at 05:15:00 am UTC time
+          rate: cron(15 10 ? * THU *) # Run every Thursday, at 08:15 pm Canberra time
           enabled: true
           input:
             year: 2018
             product: ls8_nbart_albers
       - schedule:
-          rate: cron(15 05 ? * TUE *) # Run every Tuesday, at 05:15:00 am UTC time
+          rate: cron(15 10 ? * THU *) # Run every Thursday, at 08:15 pm Canberra time
           enabled: true
           input:
             year: 2018
             product: ls8_nbar_albers
       - schedule:
-          rate: cron(15 05 ? * TUE *) # Run every Tuesday, at 05:15:00 am UTC time
+          rate: cron(15 10 ? * THU *) # Run every Thursday, at 08:15 pm Canberra time
           enabled: true
           input:
             year: 2018
@@ -164,7 +164,7 @@ functions:
                                      --tag <%= tag %>'
     events:
       - schedule:
-          rate: cron(15 14 ? * WED *) # Run every Wednesday, at 14:15:00 pm UTC time
+          rate: cron(15 10 ? * FRI *) # Run every Friday, at 08:15 pm Canberra time
           enabled: true
           input:
             year: 2018
@@ -182,7 +182,7 @@ functions:
                          --tag <%= tag %>'
     events:
       - schedule:
-          rate: cron(15 14 ? * WED *) # Run every Wednesday, at 14:15:00 pm UTC time
+          rate: cron(20 10 ? * FRI *) # Run every Friday, at 08:20 pm Canberra time
           enabled: true
           input:
             year: 2018

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -37,7 +37,7 @@ provider:
     hostkey: 'orchestrator.raijin.users.default.host'
     userkey: 'orchestrator.raijin.users.default.user'
     pkey: 'orchestrator.raijin.users.default.pkey'
-    DEA_MODULE: dea/20180815
+    DEA_MODULE: dea/20180823
     PROJECT: v10
     QUEUE: normal
   region: ap-southeast-2
@@ -69,8 +69,8 @@ functions:
       pkey: 'orchestrator.raijin.users.git_pull.pkey'
     events:
       - schedule:
-          rate: cron(02 08 ? * THU *) # Run every Thursday, at 08:02:00 am UTC time
-          enabled: false
+          rate: cron(15 00 ? * MON,TUE,WED *) # Run every Monday-Wednesday, at 00:15:00 am UTC time
+          enabled: true
   execute_sync:
     # trasharchived is set to 'yes' only for the albers products and not for the scenes
     handler: handler.execute_ssh_command
@@ -85,156 +85,44 @@ functions:
                          --trasharchived <%= trasharchived %>'
     events:
       - schedule:
-          rate: cron(10 08 ? * THU *) # Run every Thursday, at 08:10:00 am UTC time
-          enabled: false
+          rate: cron(30 00 ? * MON *) # Run every Monday, at 00:30:00 am UTC time
+          enabled: true
           input:
             year: 2018
             product: ls8_pq_scene
             path: '/g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/'
             trasharchived: no
       - schedule:
-          rate: cron(15 08 ? * THU *) # Run every Thursday, at 08:15:00 am UTC time
-          enabled: false
+          rate: cron(30 00 ? * MON *) # Run every Monday, at 00:30:00 am UTC time
+          enabled: true
           input:
             year: 2018
             product: ls8_level1_scene
             path: '/g/data/v10/reprocess/ls8/level1/2018/'
             trasharchived: no
       - schedule:
-          rate: cron(16 08 ? * THU *) # Run every Thursday, at 08:16:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/01/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(17 08 ? * THU *) # Run every Thursday, at 08:17:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/02/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(18 08 ? * THU *) # Run every Thursday, at 08:18:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/03/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(19 08 ? * THU *) # Run every Thursday, at 08:19:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/04/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(20 08 ? * THU *) # Run every Thursday, at 08:20:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(21 08 ? * THU *) # Run every Thursday, at 08:21:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/06/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(22 08 ? * THU *) # Run every Thursday, at 08:22:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(23 08 ? * THU *) # Run every Thursday, at 08:23:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/08/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(23 08 ? * THU *) # Run every Thursday, at 08:23:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/01/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(24 08 ? * THU *) # Run every Thursday, at 08:24:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/02/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(25 08 ? * THU *) # Run every Thursday, at 08:25:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/03/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(26 08 ? * THU *) # Run every Thursday, at 08:26:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/04/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(27 08 ? * THU *) # Run every Thursday, at 08:27:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/05/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(28 08 ? * THU *) # Run every Thursday, at 08:28:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/06/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(29 08 ? * THU *) # Run every Thursday, at 08:29:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/07/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(30 08 ? * THU *) # Run every Thursday, at 08:30:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/08/output/nbar/'
-            trasharchived: no
-      - schedule:
-          rate: cron(30 08 ? * THU *) # Run every Thursday, at 08:30:00 am UTC time
-          enabled: false
+          rate: cron(30 00 ? * MON *) # Run every Monday, at 00:30:00 am UTC time
+          enabled: true
           input:
             year: 2018
             product: ls8_pq_legacy_scene
             path: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls8/2018/'
+            trasharchived: no
+      - schedule:
+          rate: cron(30 00 ? * MON *) # Run every Monday, at 00:30:00 am UTC time
+          enabled: true
+          input:
+            year: 2018
+            product: ls8_nbart_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/??/output/nbart/'
+            trasharchived: no
+      - schedule:
+          rate: cron(30 00 ? * MON *) # Run every Monday, at 00:30:00 am UTC time
+          enabled: true
+          input:
+            year: 2018
+            product: ls8_nbar_scene
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/??/output/nbar/'
             trasharchived: no
   execute_ingest:
     handler: handler.execute_ssh_command
@@ -247,23 +135,59 @@ functions:
                            --product <%= product %>'
     events:
       - schedule:
-          rate: cron(00 17 ? * THU *) # Run every Thursday, at 17:00:00 pm UTC time
-          enabled: false
+          rate: cron(15 05 ? * TUE *) # Run every Tuesday, at 05:15:00 am UTC time
+          enabled: true
           input:
             year: 2018
             product: ls8_nbart_albers
       - schedule:
-          rate: cron(10 17 ? * THU *) # Run every Thursday, at 17:10:00 pm UTC time
-          enabled: false
+          rate: cron(15 05 ? * TUE *) # Run every Tuesday, at 05:15:00 am UTC time
+          enabled: true
           input:
             year: 2018
             product: ls8_nbar_albers
       - schedule:
-          rate: cron(45 11 ? * FRI *) # Run every Friday, at 11:45:00 am UTC time
-          enabled: false
+          rate: cron(15 05 ? * TUE *) # Run every Tuesday, at 05:15:00 am UTC time
+          enabled: true
           input:
             year: 2018
             product: ls8_pq_albers
+  execute_fractional_cover:
+    handler: handler.execute_ssh_command
+    environment:
+      cmd: 'execute_fractional_cover --dea-module ${self:provider.environment.DEA_MODULE}
+                                     --queue ${self:provider.environment.QUEUE}
+                                     --project ${self:provider.environment.PROJECT}
+                                     --stage ${self:custom.Stage}
+                                     --year <%= year %>
+                                     --product <%= product %>
+                                     --tag <%= tag %>'
+    events:
+      - schedule:
+          rate: cron(15 14 ? * WED *) # Run every Wednesday, at 14:15:00 pm UTC time
+          enabled: true
+          input:
+            year: 2018
+            product: ls8_fc_albers
+            tag: '2018'
+  execute_wofs:
+    handler: handler.execute_ssh_command
+    environment:
+      cmd: 'execute_wofs --dea-module ${self:provider.environment.DEA_MODULE}
+                         --queue ${self:provider.environment.QUEUE}
+                         --project ${self:provider.environment.PROJECT}
+                         --stage ${self:custom.Stage}
+                         --year <%= year %>
+                         --product <%= product %>
+                         --tag <%= tag %>'
+    events:
+      - schedule:
+          rate: cron(15 14 ? * WED *) # Run every Wednesday, at 14:15:00 pm UTC time
+          enabled: true
+          input:
+            year: 2018
+            product: wofs_albers
+            tag: '2018'
   execute_stacker:
     handler: handler.execute_ssh_command
     environment:
@@ -291,42 +215,6 @@ functions:
           input:
             year: 2018
             appconfig: ls8_pq_albers.yaml
-  execute_fractional_cover:
-    handler: handler.execute_ssh_command
-    environment:
-      cmd: 'execute_fractional_cover --dea-module ${self:provider.environment.DEA_MODULE}
-                                     --queue ${self:provider.environment.QUEUE}
-                                     --project ${self:provider.environment.PROJECT}
-                                     --stage ${self:custom.Stage}
-                                     --year <%= year %>
-                                     --product <%= product %>
-                                     --tag <%= tag %>'
-    events:
-      - schedule:
-          rate: cron(10 08 ? * THU *) # Run every Thursday, at 08:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: ls8_fc_albers
-            tag: '2018'
-  execute_wofs:
-    handler: handler.execute_ssh_command
-    environment:
-      cmd: 'execute_wofs --dea-module ${self:provider.environment.DEA_MODULE}
-                         --queue ${self:provider.environment.QUEUE}
-                         --project ${self:provider.environment.PROJECT}
-                         --stage ${self:custom.Stage}
-                         --year <%= year %>
-                         --product <%= product %>
-                         --tag <%= tag %>'
-    events:
-      - schedule:
-          rate: cron(10 10 ? * THU *) # Run every Thursday, at 10:10:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            product: wofs_albers
-            tag: '2018'
   execute_coherence:
     handler: handler.execute_ssh_command
     environment:


### PR DESCRIPTION
Following schedule was used to automate lambda execution of Sync/Ingest/WOfS/FC at the NCI:
1) Run git pull production branch every _Monday @ 00:15 am (UTC time)_.
2) Run `dea-sync` every _Monday @ 00:30 am (UTC time)_.
3) Run `dea-submit-ingest` every _Tuesday @ 05:15 am (UTC time)_.
4) Run `datacube-wofs submit` every _Wednesday @ 14:15 pm (UTC time)_.
5) Run `datacube-fc submit` every _Wednesday @ 14:15 pm (UTC time)_.