### PR TITLE
Re-add rsgislib to the NCI environment

### DIFF
--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -70,7 +70,7 @@ dependencies:
 - redis
 - redis-py
 - rios
-  #- rsgislib # Seems to pull in old gdal
+- rsgislib
 - rtree
 - scikit-image
 - scikit-learn


### PR DESCRIPTION
It was removed due to broken dependencies, but should be fixed now.