### PR TITLE
Add rasterstats/jupyter lab extension modules and fix build issue

### DIFF
--- a/raijin_scripts/deploy/README.md
+++ b/raijin_scripts/deploy/README.md
@@ -81,7 +81,7 @@ It requires python 3.6+ and pyyaml. Run the following on raijin at the NCI:
 
       $ module use /g/data/v10/public/modules/modulefiles/
       $ module load python3/3.6.2
-      $ ./build_environment_module.py dea-env/modulespec.yaml True
+      $ ./build_environment_module.py dea-env/modulespec.yaml
 
 This will build a new environment module for today.
 
@@ -94,7 +94,7 @@ A DEA module will specify one exact environment module.
 
     $ module use /g/data/v10/public/modules/modulefiles/
     $ module load python3/3.6.2
-    $ ./build_environment_module.py dea/modulespec.yaml False
+    $ ./build_environment_module.py dea/modulespec.yaml
 
 ## Updating the Default Version
 

--- a/raijin_scripts/deploy/README.md
+++ b/raijin_scripts/deploy/README.md
@@ -77,7 +77,11 @@ run from VDI.
 
 ## Building a new _Environment Module_
 
-    ./build_environment_module.py
+It requires python 3.6+ and pyyaml. Run the following on raijin at the NCI:
+
+      $ module use /g/data/v10/public/modules/modulefiles/
+      $ module load python3/3.6.2
+      $ ./build_environment_module.py dea-env/modulespec.yaml True
 
 This will build a new environment module for today.
 
@@ -88,8 +92,9 @@ of all of our pip/conda dependencies on that date.
 
 A DEA module will specify one exact environment module.
 
-    ./build_dea_module.py [<environment_module>]
-
+    $ module use /g/data/v10/public/modules/modulefiles/
+    $ module load python3/3.6.2
+    $ ./build_environment_module.py dea/modulespec.yaml False
 
 ## Updating the Default Version
 
@@ -102,4 +107,4 @@ Eg. For `dea` this is: `/g/data/v10/public/modules/modulefiles/dea/.version`
 
 ## Archiving an old module
 
-...
+[TO DO]...

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -79,6 +79,9 @@ def install_conda_packages(env_file, variables):
     module_path = variables['module_path']
 
     run(f"{conda_path} env create -p {module_path} -v --file {env_file}")
+    
+    # Activate the new environment
+    run(f"source activate {module_path}")
 
 
 def write_template(template_file, variables, output_file):

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -114,8 +114,8 @@ def run_command(cmd: str):
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT,
                                      universal_newlines=True,
-                                     encoding='ascii')
-        LOG.debug(proc_output.stdout)
+                                     encoding='iso-8859-1')
+        LOG.debug(proc_output.stdout.decode('iso-8859-1'))
     except subprocess.CalledProcessError as suberror:
         LOG.exception("Failed : %s" % suberror.stdout)
 
@@ -287,8 +287,8 @@ def find_default_version(module_name):
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT,
                             universal_newlines=True,
-                            encoding='ascii')
-    LOG.debug(output.stdout)
+                            encoding='iso-8859-1')
+    LOG.debug(output.stdout.decode('iso-8859-1'))
     versions = [version for version in output.stdout.splitlines() if f'{module_name}/' in version]
     default_version = [version for version in versions if '(default)' in version]
     if default_version:

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -43,14 +43,14 @@ from time import sleep
 MODULE_DIR = '/g/data/v10/public/modules'
 
 LOG_NAME = "build_dea_module.log"
-file_handler = logging.FileHandler(filename=LOG_NAME, mode='w')
-stdout_handler = logging.StreamHandler(sys.stdout)
-handlers = [file_handler, stdout_handler]
+FILE_HANDLER = logging.FileHandler(filename=LOG_NAME, mode='w')
+STDOUT_HANDLER = logging.StreamHandler(sys.stdout)
+HANDLERS = [FILE_HANDLER, STDOUT_HANDLER]
 
 logging.basicConfig(
     level=logging.DEBUG,
     format='[%(asctime)s] {%(filename)30s:%(lineno)3d} %(levelname)s: %(message)s',
-    handlers=handlers
+    handlers=HANDLERS
 )
 
 LOG = logging.getLogger('build-dea-module')
@@ -122,7 +122,7 @@ def run_command(cmd: str):
             log_output = proc_output.stdout
         LOG.debug(log_output)
     except subprocess.CalledProcessError as suberror:
-        LOG.exception("Failed : %s" % suberror.stdout)
+        LOG.exception("Failed : %s", suberror.stdout)
 
 
 def install_conda_packages(env_file, variables):
@@ -301,12 +301,14 @@ def find_default_version(module_name):
     LOG.debug(log_output)
     versions = [version for version in output.stdout.splitlines() if f'{module_name}/' in version]
     default_version = [version for version in versions if '(default)' in version]
+
     if default_version:
-        return default_version[0].replace('(default)', '')
+        ret_val = default_version[0].replace('(default)', '')
     elif len(versions) > 0:
-        return versions[-1]
+        ret_val = versions[-1]
     else:
         raise Exception('No version of module %s is available.' % module_name)
+    return ret_val
 
 
 def run_final_commands_on_module(commands, module_path):

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -86,7 +86,7 @@ def write_template(template_file, variables, output_file):
     LOG.debug(' Filling template file %s to %s', template_file, output_file)
     LOG.debug(' Ensuring parent dir %s exists', output_file.parent)
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    sleep(5) # sleep 5 seconds
+    sleep(5)  # sleep 5 seconds
 
     template_contents = template_file.read_text()
     template = string.Template(template_contents)

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -114,8 +114,13 @@ def run_command(cmd: str):
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT,
                                      universal_newlines=True,
-                                     encoding='iso-8859-1')
-        LOG.debug(proc_output.stdout.decode('iso-8859-1'))
+                                     encoding='utf-8',
+                                     errors='replace')
+        try:
+            log_output = proc_output.stdout.decode('utf-8')
+        except (AttributeError, UnicodeDecodeError):
+            log_output = proc_output.stdout
+        LOG.debug(log_output)
     except subprocess.CalledProcessError as suberror:
         LOG.exception("Failed : %s" % suberror.stdout)
 
@@ -287,8 +292,13 @@ def find_default_version(module_name):
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT,
                             universal_newlines=True,
-                            encoding='iso-8859-1')
-    LOG.debug(output.stdout.decode('iso-8859-1'))
+                            encoding='utf-8',
+                            errors='replace')
+    try:
+        log_output = output.stdout.decode('utf-8')
+    except (AttributeError, UnicodeDecodeError):
+        log_output = output.stdout
+    LOG.debug(log_output)
     versions = [version for version in output.stdout.splitlines() if f'{module_name}/' in version]
     default_version = [version for version in versions if '(default)' in version]
     if default_version:

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -352,7 +352,7 @@ def main(config_path):
         LOG.debug('Re-install miniconda3 before creating new dea-environment module')
         scriptname = config['dea_env_miniconda3']
         run_command(f'./{scriptname}')
-    
+
     config['variables']['module_version'] = date()
     include_templated_vars(config)
     include_stable_module_dep_versions(config)

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -348,11 +348,11 @@ def main(config_path):
     config = read_config(config_path)
     variables = config['variables']
 
-    if 'reinstall_miniconda_package' in config:
+    if 'dea_env_miniconda3' in config:
         LOG.debug('Re-install miniconda3 before creating new dea-environment module')
-        scriptname = config['reinstall_miniconda_package']
+        scriptname = config['dea_env_miniconda3']
         run_command(f'./{scriptname}')
-
+    
     config['variables']['module_version'] = date()
     include_templated_vars(config)
     include_stable_module_dep_versions(config)
@@ -373,8 +373,10 @@ def main(config_path):
     if 'finalise_commands' in config and config['finalise_commands']:
         run_final_commands_on_module(config['finalise_commands'], variables['module_path'])
 
-    LOG.debug('Installed packages and their versions:')
-    run_command(f'pip freeze')
+    if 'dea_env_miniconda3' in config:
+        LOG.debug('List installed packages and their versions:')
+        module_path = variables['module_path']
+        run_command(f'{module_path}/bin/bin freeze')
 
     fix_module_permissions(variables['module_path'])
     shutil.move(ospath + '/' + LOG_NAME, variables['module_path'] + '/' + LOG_NAME)

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -4,90 +4,188 @@ channels:
 - defaults
 - nodefaults
 dependencies:
+- affine >= 2.2.1
+- asn1crypto >= 0.24.0
+- attrs >= 18.1.0
 - basemap
 - bottleneck
+- boost-cpp >= 1.67.0
+- boto3 >= 1.7.80 
 - bqplot
+- botocore >= 1.10.80
+- bzip2 >= 1.0.6
+- ca-certificates >= 2018.8.13
 - cachetools
+- cairo >= 1.14.12
+- certifi >= 2018.8.13
 - cartopy
-- certifi
-- click
-- cligj >= 0.4
+- cffi >= 1.11.5
+- chardet >= 3.0.4
+- click >= 6.7
+- click-plugins >= 1.0.3
+- cligj >= 0.4.0
 - compliance-checker
+- conda >= 4.5.11
+- conda-env >= 2.6.0
+- cryptography >= 2.3
+- cryptography-vectors >= 2.3
+- curl >= 7.61.0
 - cython
 - dask
 - distributed
+- docutils >= 0.14
 - ephem
-- fiona
+- expat >= 2.2.5
+- fiona >= 1.7.13
 - folium
+- fontconfig >= 2.13.0
 - future
+- freetype >= 2.9.1
+- freexl >= 1.0.5
 - gdal >= 2.2.4
 - geopandas
 - geopy
+- geos >= 3.6.2
+- geotiff >= 1.4.2
+- gettext >= 0.19.8.1
+- giflib >= 5.1.4
+- glib >= 2.55.0
 - glueviz
-- graphviz  # This is only graphviz itself, not the python bindings. The latter are in the pip section.
-- h5py
-- hdf5
+- graphviz # This is only graphviz itself, not the python bindings. The latter are in the pip section.
+- hdf4 >= 4.2.13
+- hdf5 >= 1.10.2
 - hypothesis
+- icu >= 58.2
+- idna >= 2.7
+- intel-openmp >= 2018.0.3 
 - ipdb
 - ipyleaflet
 - ipympl
 - ipywidgets
+- jmespath >= 0.9.3
+- jpeg >= 9c
 - jplephem
+- json-c >= 0.12.1 
 - jsonschema
 - jupyter
 - jupyter_contrib_nbextensions
 - jupyter_dashboards
-- jupyterlab
+- jupyterlab = 0.33.0
 - keras
+- kealib >= 1.4.9
+- krb5 >= 1.14.6
+- libedit >= 3.1.20170329
+- libffi >= 3.2.1
+- libgcc-ng >= 8.2.0
+- libgdal >= 2.2.4
+- libgfortran >= 3.0.0
+- libgfortran-ng >= 7.2.0
+- libiconv >= 1.15
+- libkml >= 1.3.0
+- libnetcdf >= 4.6.1
+- libpng >= 1.6.35
+- libpq >= 9.6.3
+- libspatialite >= 4.3.0a
+- libssh2 >= 1.8.0
+- libstdcxx-ng >= 8.2.0
+- libtiff >= 4.0.9
+- libuuid >= 2.32.1
+- libxcb >= 1.13
+- libxml2 >= 2.9.8 
 - line_profiler
 - luigi
 - matplotlib
-#- memory_profiler # Rasterstats depends on memory_profiler from anaconda channel 
+  #- memory_profiler # Rasterstats depends on memory_profiler from anaconda channel 
   #- mkl-service
+- mkl >= 2018.0.3
+- mkl_fft >= 1.0.5
+- mkl_random >= 1.0.1
 - mock
+- munch >= 2.3.2
+- ncurses >= 6.1
 - netcdf4
-- nodejs
+  #- nodejs = 9.11.1  # Jupyter lab build fails with Node v10.4.1 and yarn v1.9.4 (Ref: https://github.com/jupyterlab/jupyterlab/issues/4585, #4804). 
 - numba
 - numexpr
 - numpy >= 1.9
-  #- openblas
-- openssl
+- numpy >= 1.14.2
+- openjpeg >= 2.3.0
+- openssl >= 1.0.2o
 - pandas
+- pcre >= 8.41
 - pep8
-- pip
+- pixman >= 0.34.0
 - plotly
-- psutil
+- poppler >= 0.61.1
+- poppler-data >= 0.4.9
+- proj4 >= 4.9.3
+- psutil >= 5.4.6
+- pthread-stubs >= 0.4 
 - psycopg2
 - py6s
+- pycosat >= 0.6.3
+- pycparser >= 2.18 
 - pylint
+- pyopenssl >= 18.0.0
+- pyparsing >= 2.2.0
+- pysocks >= 1.6.8
 - pytables
 - pytest
 - pytest-cov
+- python >= 3.6.6
+- python-dateutil >= 2.7.3
 - pyyaml
-- python = 3.6
-# - qgis >= 3  # QGIS 3 is not being built for linux64 yet. See https://github.com/conda-forge/qgis-feedstock/pull/36
-- rasterio >= 1.0.2  # required for zip reading
-- rasterstats
+- rasterio >= 1.0.3
+- rasterstats >= 0.13.0
+- readline >= 7.0
+- recommonmark
 - redis
 - redis-py
+- requests >= 2.19.1
 - rios
 - rsgislib
+- ruamel_yaml >= 0.15.46
 - rtree
+- s3transfer >= 0.1.13
 - scikit-image
 - scikit-learn
 - scipy
 - seaborn
-- shapely
-- simplejson
+- setuptools >= 40.0.0
+- shapely >= 1.6.4
+- simplejson >= 3.16.0
 - singledispatch
+- six >= 1.11.0
+- snuggs >= 1.4.1
 - spectral
-- sphinx
+- sphinx >= 1.6
+- sphinx_rtd_theme
 - spyder
 - sqlalchemy
+- sqlite >= 3.24.0
+- tk >= 8.6.7
 - tqdm
 - tuiview
-- xarray
+- urllib3 >= 1.23
 - voluptuous
+- wheel >= 0.31.1
+- xarray
+- xerces-c >= 3.2.0
+- xorg-kbproto >= 1.0.7
+- xorg-libice >= 1.0.9
+- xorg-libsm >= 1.2.2
+- xorg-libx11 >= 1.6.5
+- xorg-libxau >= 1.0.8
+- xorg-libxdmcp >= 1.1.2
+- xorg-libxext >= 1.3.3
+- xorg-libxrender >= 0.9.10
+- xorg-renderproto >= 0.11.1
+- xorg-xextproto >= 7.3.0
+- xorg-xproto >= 7.0.31
+- xz >= 5.2.4
+- yaml >= 0.1.7
+  #- yarn = 1.6.0 # Jupyter lab build fails with Node v10.4.1 and yarn v1.9.4 (Ref: https://github.com/jupyterlab/jupyterlab/issues/4585). 
+- zlib >= 1.2.11
 - pip:
   - autopep8
   - awscli

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -11,6 +11,7 @@ dependencies:
 - cartopy
 - certifi
 - click
+- cligj >= 0.4
 - compliance-checker
 - cython
 - dask
@@ -41,14 +42,14 @@ dependencies:
 - line_profiler
 - luigi
 - matplotlib
-- memory_profiler
+#- memory_profiler # Rasterstats depends on memory_profiler from anaconda channel 
   #- mkl-service
 - mock
 - netcdf4
 - nodejs
 - numba
 - numexpr
-- numpy
+- numpy >= 1.9
   #- openblas
 - openssl
 - pandas
@@ -77,6 +78,7 @@ dependencies:
 - scipy
 - seaborn
 - shapely
+- simplejson
 - singledispatch
 - spectral
 - sphinx

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -68,7 +68,7 @@ dependencies:
 - jupyter
 - jupyter_contrib_nbextensions
 - jupyter_dashboards
-  #- jupyterlab # Not intended for production/distribution environment
+- jupyterlab >= 0.34.2
 - keras
 - kealib >= 1.4.9
 - krb5 >= 1.14.6

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -1,8 +1,6 @@
 name: dea-env
 channels:
 - conda-forge
-- defaults
-- nodefaults
 dependencies:
 - affine >= 2.2.1
 - asn1crypto >= 0.24.0
@@ -70,7 +68,7 @@ dependencies:
 - jupyter
 - jupyter_contrib_nbextensions
 - jupyter_dashboards
-- jupyterlab = 0.33.0
+  #- jupyterlab # Not intended for production/distribution environment
 - keras
 - kealib >= 1.4.9
 - krb5 >= 1.14.6
@@ -95,16 +93,18 @@ dependencies:
 - line_profiler
 - luigi
 - matplotlib
-  #- memory_profiler # Rasterstats depends on memory_profiler from anaconda channel 
+- memory_profiler
   #- mkl-service
 - mkl >= 2018.0.3
 - mkl_fft >= 1.0.5
 - mkl_random >= 1.0.1
 - mock
 - munch >= 2.3.2
+- nb_conda_kernels
 - ncurses >= 6.1
 - netcdf4
-  #- nodejs = 9.11.1  # Jupyter lab build fails with Node v10.4.1 and yarn v1.9.4 (Ref: https://github.com/jupyterlab/jupyterlab/issues/4585, #4804). 
+- nodejs
+- notebook
 - numba
 - numexpr
 - numpy >= 1.9
@@ -163,12 +163,15 @@ dependencies:
 - spyder
 - sqlalchemy
 - sqlite >= 3.24.0
+- tornado
 - tk >= 8.6.7
 - tqdm
 - tuiview
 - urllib3 >= 1.23
+- vega_datasets
 - voluptuous
 - wheel >= 0.31.1
+- widgetsnbextension
 - xarray
 - xerces-c >= 3.2.0
 - xorg-kbproto >= 1.0.7
@@ -184,7 +187,7 @@ dependencies:
 - xorg-xproto >= 7.0.31
 - xz >= 5.2.4
 - yaml >= 0.1.7
-  #- yarn = 1.6.0 # Jupyter lab build fails with Node v10.4.1 and yarn v1.9.4 (Ref: https://github.com/jupyterlab/jupyterlab/issues/4585). 
+- yarn
 - zlib >= 1.2.11
 - pip:
   - autopep8

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -34,6 +34,7 @@ dependencies:
 - docutils >= 0.14
 - ephem
 - expat >= 2.2.5
+- ffmpeg
 - fiona >= 1.7.13
 - folium
 - fontconfig >= 2.13.0
@@ -52,6 +53,7 @@ dependencies:
 - graphviz # This is only graphviz itself, not the python bindings. The latter are in the pip section.
 - hdf4 >= 4.2.13
 - hdf5 >= 1.10.2
+- h5py
 - hypothesis
 - icu >= 58.2
 - idna >= 2.7
@@ -107,7 +109,6 @@ dependencies:
 - notebook
 - numba
 - numexpr
-- numpy >= 1.9
 - numpy >= 1.14.2
 - openjpeg >= 2.3.0
 - openssl >= 1.0.2o

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -2,194 +2,166 @@ name: dea-env
 channels:
 - conda-forge
 dependencies:
-- affine >= 2.2.1
-- asn1crypto >= 0.24.0
-- attrs >= 18.1.0
+- affine
+- attrs
 - basemap
 - bottleneck
-- boost-cpp >= 1.67.0
-- boto3 >= 1.7.80 
+- boost-cpp
+- boto3
 - bqplot
-- botocore >= 1.10.80
-- bzip2 >= 1.0.6
-- ca-certificates >= 2018.8.13
+- botocore
 - cachetools
-- cairo >= 1.14.12
-- certifi >= 2018.8.13
+- cairo
 - cartopy
-- cffi >= 1.11.5
-- chardet >= 3.0.4
-- click >= 6.7
-- click-plugins >= 1.0.3
-- cligj >= 0.4.0
+- click
+- click-plugins
+- cligj
 - compliance-checker
-- conda >= 4.5.11
-- conda-env >= 2.6.0
-- cryptography >= 2.3
-- cryptography-vectors >= 2.3
-- curl >= 7.61.0
+- conda
+- conda-env
+- curl
 - cython
-- dask
-- distributed
-- docutils >= 0.14
+- dask = 0.18.2  # Existing datacube app has issue with 0.19.0 version
+- distributed = 1.22.0 # Existing datacube app has issue with 1.23.0 version
+- docutils
 - ephem
-- expat >= 2.2.5
+- expat
 - ffmpeg
-- fiona >= 1.7.13
+- fiona
 - folium
-- fontconfig >= 2.13.0
+- fontconfig
 - future
-- freetype >= 2.9.1
-- freexl >= 1.0.5
+- freetype
+- freexl
 - gdal >= 2.2.4
 - geopandas
 - geopy
-- geos >= 3.6.2
-- geotiff >= 1.4.2
-- gettext >= 0.19.8.1
-- giflib >= 5.1.4
-- glib >= 2.55.0
+- geos
+- geotiff
+- gettext
+- giflib
+- glib
 - glueviz
+- glue-geospatial
 - graphviz # This is only graphviz itself, not the python bindings. The latter are in the pip section.
-- hdf4 >= 4.2.13
-- hdf5 >= 1.10.2
+- hdf4
+- hdf5
 - h5py
 - hypothesis
-- icu >= 58.2
-- idna >= 2.7
-- intel-openmp >= 2018.0.3 
+- icu
+- intel-openmp
 - ipdb
 - ipyleaflet
 - ipympl
 - ipywidgets
-- jmespath >= 0.9.3
-- jpeg >= 9c
+- jmespath
+- jpeg
 - jplephem
-- json-c >= 0.12.1 
+- json-c
 - jsonschema
 - jupyter
 - jupyter_contrib_nbextensions
 - jupyter_dashboards
-- jupyterlab >= 0.34.2
+- jupyterlab
 - keras
-- kealib >= 1.4.9
-- krb5 >= 1.14.6
-- libedit >= 3.1.20170329
-- libffi >= 3.2.1
-- libgcc-ng >= 8.2.0
-- libgdal >= 2.2.4
-- libgfortran >= 3.0.0
-- libgfortran-ng >= 7.2.0
-- libiconv >= 1.15
-- libkml >= 1.3.0
-- libnetcdf >= 4.6.1
-- libpng >= 1.6.35
-- libpq >= 9.6.3
-- libspatialite >= 4.3.0a
-- libssh2 >= 1.8.0
-- libstdcxx-ng >= 8.2.0
-- libtiff >= 4.0.9
-- libuuid >= 2.32.1
-- libxcb >= 1.13
-- libxml2 >= 2.9.8 
+- kealib
+- krb5
+- libgdal
+- libgfortran
+- libgfortran-ng
+- libiconv
+- libkml
+- libnetcdf
+- libpng
+- libpq
+- libspatialite
+- libssh2
+- libtiff
+- libuuid
+- libxcb
+- libxml2
 - line_profiler
 - luigi
 - matplotlib
 - memory_profiler
   #- mkl-service
-- mkl >= 2018.0.3
-- mkl_fft >= 1.0.5
-- mkl_random >= 1.0.1
+- mkl
+- mkl_fft
+- mkl_random
 - mock
-- munch >= 2.3.2
+- munch
 - nb_conda_kernels
-- ncurses >= 6.1
 - netcdf4
 - nodejs
 - notebook
 - numba
 - numexpr
-- numpy >= 1.14.2
-- openjpeg >= 2.3.0
-- openssl >= 1.0.2o
+- numpy
+- openjpeg
 - pandas
-- pcre >= 8.41
+- pcre
 - pep8
-- pixman >= 0.34.0
+- pixman
 - plotly
-- poppler >= 0.61.1
-- poppler-data >= 0.4.9
-- proj4 >= 4.9.3
-- psutil >= 5.4.6
-- pthread-stubs >= 0.4 
+- poppler
+- poppler-data
+- proj4
+- psutil
+- pthread-stubs
 - psycopg2
 - py6s
-- pycosat >= 0.6.3
-- pycparser >= 2.18 
 - pylint
-- pyopenssl >= 18.0.0
-- pyparsing >= 2.2.0
-- pysocks >= 1.6.8
+- pyparsing
 - pytables
 - pytest
 - pytest-cov
 - python >= 3.6.6
-- python-dateutil >= 2.7.3
+- python-dateutil
 - pyyaml
 - rasterio >= 1.0.3
 - rasterstats >= 0.13.0
-- readline >= 7.0
 - recommonmark
 - redis
 - redis-py
-- requests >= 2.19.1
 - rios
 - rsgislib
-- ruamel_yaml >= 0.15.46
 - rtree
-- s3transfer >= 0.1.13
+- s3transfer
 - scikit-image
 - scikit-learn
 - scipy
 - seaborn
-- setuptools >= 40.0.0
-- shapely >= 1.6.4
-- simplejson >= 3.16.0
+- shapely
+- simplejson
 - singledispatch
-- six >= 1.11.0
-- snuggs >= 1.4.1
+- snuggs
 - spectral
-- sphinx >= 1.6
+- sphinx
 - sphinx_rtd_theme
 - spyder
 - sqlalchemy
-- sqlite >= 3.24.0
+- sqlite
 - tornado
-- tk >= 8.6.7
 - tqdm
 - tuiview
-- urllib3 >= 1.23
 - vega_datasets
 - voluptuous
-- wheel >= 0.31.1
 - widgetsnbextension
 - xarray
-- xerces-c >= 3.2.0
-- xorg-kbproto >= 1.0.7
+- xerces-c
+- xorg-kbproto
 - xorg-libice >= 1.0.9
-- xorg-libsm >= 1.2.2
-- xorg-libx11 >= 1.6.5
-- xorg-libxau >= 1.0.8
-- xorg-libxdmcp >= 1.1.2
-- xorg-libxext >= 1.3.3
-- xorg-libxrender >= 0.9.10
-- xorg-renderproto >= 0.11.1
-- xorg-xextproto >= 7.3.0
-- xorg-xproto >= 7.0.31
-- xz >= 5.2.4
-- yaml >= 0.1.7
+- xorg-libsm
+- xorg-libx11
+- xorg-libxau
+- xorg-libxdmcp
+- xorg-libxext
+- xorg-libxrender
+- xorg-renderproto
+- xorg-xextproto
+- xorg-xproto
+- yaml
 - yarn
-- zlib >= 1.2.11
 - pip:
   - autopep8
   - awscli

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -22,11 +22,10 @@ template_files:
   chmod: 0o444
 
 finalise_commands:
+#- jupyter lab clean
 #- jupyter labextension install --no-build jupyterlab-toc
 #- jupyter labextension install --no-build jupyterlab_bokeh
 #- jupyter labextension install --no-build @jupyterlab/github
 #- jupyter labextension install --no-build @jupyterlab/geojson-extension
 #- jupyter labextension install --no-build jupyter-leaflet Hanging on install
 #- jupyter lab build
-- jupyter lab clean
-- NODE_OPTIONS=--no-deprecation jupyter lab build --debug

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -27,4 +27,6 @@ finalise_commands:
 #- jupyter labextension install --no-build @jupyterlab/github
 #- jupyter labextension install --no-build @jupyterlab/geojson-extension
 #- jupyter labextension install --no-build jupyter-leaflet Hanging on install
-- jupyter lab build
+#- jupyter lab build
+- jupyter lab clean
+- NODE_OPTIONS=--no-deprecation jupyter lab build --debug

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -20,7 +20,3 @@ template_files:
 - src: modulefile.template
   dest: "{modules_dir}/modulefiles/{module_name}/{module_version}"
   chmod: 0o444
-
-finalise_commands:
-- jupyter lab clean
-- jupyter lab build

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -12,7 +12,7 @@ templated_variables:
 
 install_conda_packages: environment.yaml
 
-reinstall_miniconda_package: reinstall_miniconda.sh
+dea_env_miniconda3: reinstall_miniconda.sh
 
 copy_files:
 - src: environment.yaml

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -12,6 +12,8 @@ templated_variables:
 
 install_conda_packages: environment.yaml
 
+reinstall_miniconda_package: reinstall_miniconda.sh
+
 copy_files:
 - src: environment.yaml
   dest: "{modules_dir}/{module_name}/{module_version}/environment.yaml"

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -2,7 +2,7 @@ variables:
   module_name: dea-env
   module_description: DEA Environment Module
   modules_dir: "/g/data/v10/public/modules"
-  conda_path: "/g/data/v10/private/miniconda3/bin/conda"
+  conda_path: "/g/data/v10/private/miniconda3-new/bin/conda"
 #  module_version: This is filled in automatically
 
 # These templated variables are filled and included in the available variables used

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -3,7 +3,7 @@ variables:
   module_description: DEA Environment Module
   modules_dir: "/g/data/v10/public/modules"
   conda_path: "/g/data/v10/private/miniconda3-new/bin/conda"
-#  module_version: This is filled in automatically
+  # module_version: This is filled in automatically
 
 # These templated variables are filled and included in the available variables used
 # in template files and configuration sections below
@@ -20,3 +20,10 @@ template_files:
 - src: modulefile.template
   dest: "{modules_dir}/modulefiles/{module_name}/{module_version}"
   chmod: 0o444
+
+finalise_commands:
+- jupyter labextension install jupyterlab_bokeh
+- jupyter labextension install @jupyterlab/geojson-extension
+- jupyter labextension install @jupyterlab/github
+- jupyter labextension install @jupyterlab/toc
+- jupyter lab build

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -22,10 +22,5 @@ template_files:
   chmod: 0o444
 
 finalise_commands:
-#- jupyter lab clean
-#- jupyter labextension install --no-build jupyterlab-toc
-#- jupyter labextension install --no-build jupyterlab_bokeh
-#- jupyter labextension install --no-build @jupyterlab/github
-#- jupyter labextension install --no-build @jupyterlab/geojson-extension
-#- jupyter labextension install --no-build jupyter-leaflet Hanging on install
-#- jupyter lab build
+- jupyter lab clean
+- jupyter lab build

--- a/raijin_scripts/deploy/dea/modulespec.yaml
+++ b/raijin_scripts/deploy/dea/modulespec.yaml
@@ -30,10 +30,3 @@ copy_files:
 template_files:
 - src: modulefile.template
   dest: "{modules_base}/modulefiles/{module_name}/{module_version}"
-
-finalise_commands:
-- jupyter labextension install jupyterlab_bokeh
-- jupyter labextension install @jupyterlab/geojson-extension
-- jupyter labextension install @jupyterlab/github
-- jupyter labextension install @jupyterlab/toc
-- jupyter lab build

--- a/raijin_scripts/deploy/dea/modulespec.yaml
+++ b/raijin_scripts/deploy/dea/modulespec.yaml
@@ -30,3 +30,10 @@ copy_files:
 template_files:
 - src: modulefile.template
   dest: "{modules_base}/modulefiles/{module_name}/{module_version}"
+
+finalise_commands:
+- jupyter labextension install jupyterlab_bokeh
+- jupyter labextension install @jupyterlab/geojson-extension
+- jupyter labextension install @jupyterlab/github
+- jupyter labextension install @jupyterlab/toc
+- jupyter lab build

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -7,12 +7,6 @@ curl -o "$TMPDIR/miniconda.sh" https://repo.continuum.io/miniconda/Miniconda3-la
 chmod +x "$TMPDIR/miniconda.sh"
 cd "$TMPDIR" || exit
 ./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
-#"$MINICONDA_PATH"/bin/conda update -y -n base --all
-"$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip
-"$MINICONDA_PATH"/bin/conda install -y -c anaconda memory_profiler
-"$MINICONDA_PATH"/bin/conda install -y -c conda-forge ipywidgets widgetsnbextension 'nodejs<10' notebook nb_conda_kernels jupyterlab=0.33.0
-
-#"$MINICONDA_PATH"/bin/conda install -c conda-forge --override-channels --yes python=3.6 pip cookiecutter=1.6 notebook=5.5 pandas=0.23 nodejs=9.11 jupyterlab bqplot ipyvolume pythreejs
-#"$MINICONDA_PATH"/bin/jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-threejs ipyvolume bqplot @jupyterlab/geojson-extension @jupyterlab/fasta-extension
-#"$MINICONDA_PATH"/bin/conda install -y -c conda-forge yarn=1.6.0
+"$MINICONDA_PATH"/bin/conda update -y -n base --all
+"$MINICONDA_PATH"/bin/conda install -y --override-channels -c conda-forge pip tar
 chmod -R ug+rw "$MINICONDA_PATH"

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -1,22 +1,12 @@
 #!/bin/bash
 
-#MINICONDA_PATH=/g/data/v10/private/miniconda3-new
+MINICONDA_PATH=/g/data/v10/private/miniconda3-new
 
-#rm -rf "$MINICONDA_PATH"
-#curl -o "$TMPDIR/miniconda.sh" https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-#chmod +x "$TMPDIR/miniconda.sh"
-#cd "$TMPDIR" || exit
-#./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
-#"$MINICONDA_PATH"/bin/conda update -y -n base conda
-#"$MINICONDA_PATH"/bin/conda install -y --override-channels -c conda-forge nodejs jupyterlab
-#"$MINICONDA_PATH"/bin/jupyter lab build
-#chmod -R ug+rw "$MINICONDA_PATH"
-
-rm -rf /g/data/v10/private/miniconda3-new
+rm -rf "$MINICONDA_PATH"
 curl -o "$TMPDIR/miniconda.sh" https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 chmod +x "$TMPDIR/miniconda.sh"
 cd "$TMPDIR" || exit
-./miniconda.sh -b -f -u -p /g/data/v10/private/miniconda3-new
-/g/data/v10/private/miniconda3-new/bin/conda install -y --override-channels -c conda-forge nodejs jupyterlab=0.34.2
-/g/data/v10/private/miniconda3-new/bin/jupyter lab build
-#/g/data/v10/private/miniconda3/bin/conda update -y -n base conda
+./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
+"$MINICONDA_PATH"/bin/conda update -y -n base --all
+"$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip
+chmod -R ug+rw "$MINICONDA_PATH"

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -7,8 +7,8 @@ curl -o "$TMPDIR/miniconda.sh" https://repo.continuum.io/miniconda/Miniconda3-la
 chmod +x "$TMPDIR/miniconda.sh"
 cd "$TMPDIR" || exit
 ./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
-"$MINICONDA_PATH"/bin/conda update -y -c conda-forge --override-channels --all
-"$MINICONDA_PATH"/bin/conda install -y -c conda-forge --override-channels pip
+"$MINICONDA_PATH"/bin/conda update -y -c conda-forge --all
+"$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip
 
 if [ ! -d "$HOME"/.nvm ]
 then

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-rm -rf /g/data/v10/private/miniconda3
+MINICONDA_PATH=/g/data/v10/private/miniconda3-new
+
+rm -rf "$MINICONDA_PATH"
 curl -o "$TMPDIR/miniconda.sh" https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 chmod +x "$TMPDIR/miniconda.sh"
 cd "$TMPDIR" || exit
-./miniconda.sh -b -f -u -p /g/data/v10/private/miniconda3
-/g/data/v10/private/miniconda3/bin/conda update -y -n base conda
+./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
+"$MINICONDA_PATH"/bin/conda update -y -n base --all
+"$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip
+"$MINICONDA_PATH"/bin/conda install -y -c anaconda memory_profiler

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -7,6 +7,12 @@ curl -o "$TMPDIR/miniconda.sh" https://repo.continuum.io/miniconda/Miniconda3-la
 chmod +x "$TMPDIR/miniconda.sh"
 cd "$TMPDIR" || exit
 ./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
-"$MINICONDA_PATH"/bin/conda update -y -n base --all
+#"$MINICONDA_PATH"/bin/conda update -y -n base --all
 "$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip
 "$MINICONDA_PATH"/bin/conda install -y -c anaconda memory_profiler
+"$MINICONDA_PATH"/bin/conda install -y -c conda-forge ipywidgets widgetsnbextension 'nodejs<10' notebook nb_conda_kernels jupyterlab=0.33.0
+
+#"$MINICONDA_PATH"/bin/conda install -c conda-forge --override-channels --yes python=3.6 pip cookiecutter=1.6 notebook=5.5 pandas=0.23 nodejs=9.11 jupyterlab bqplot ipyvolume pythreejs
+#"$MINICONDA_PATH"/bin/jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-threejs ipyvolume bqplot @jupyterlab/geojson-extension @jupyterlab/fasta-extension
+#"$MINICONDA_PATH"/bin/conda install -y -c conda-forge yarn=1.6.0
+chmod -R ug+rw "$MINICONDA_PATH"

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MINICONDA_PATH=/g/data/v10/private/miniconda3-new
 
@@ -7,6 +7,35 @@ curl -o "$TMPDIR/miniconda.sh" https://repo.continuum.io/miniconda/Miniconda3-la
 chmod +x "$TMPDIR/miniconda.sh"
 cd "$TMPDIR" || exit
 ./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
-"$MINICONDA_PATH"/bin/conda update -y -n base --all
-"$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip
+"$MINICONDA_PATH"/bin/conda update -y -c conda-forge --override-channels --all
+"$MINICONDA_PATH"/bin/conda install -y -c conda-forge --override-channels pip
+
+if [ ! -d "$HOME"/.nvm ]
+then
+    # Git install Node Version Manager
+    echo "Installing NVM"
+    cd ~/ || exit
+    git clone https://github.com/creationix/nvm.git .nvm
+    cd ~/.nvm || exit
+    git checkout v0.33.11
+else
+    echo "~/.nvm directory already exists"
+fi
+
+cd ~/.nvm || exit
+export NVM_DIR="$HOME/.nvm"
+
+# shellcheck source=/dev/null
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+
+# shellcheck source=/dev/null
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+# shellcheck source=/dev/null
+. "$NVM_DIR/nvm.sh"
+
+git checkout master
+git pull
+nvm_version=$(nvm --version)
+echo "NVM version = $nvm_version"
 chmod -R ug+rwx "$MINICONDA_PATH"

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -9,4 +9,4 @@ cd "$TMPDIR" || exit
 ./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
 "$MINICONDA_PATH"/bin/conda update -y -n base --all
 "$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip
-chmod -R ug+rw "$MINICONDA_PATH"
+chmod -R ug+rwx "$MINICONDA_PATH"

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
 
-MINICONDA_PATH=/g/data/v10/private/miniconda3-new
+#MINICONDA_PATH=/g/data/v10/private/miniconda3-new
 
-rm -rf "$MINICONDA_PATH"
+#rm -rf "$MINICONDA_PATH"
+#curl -o "$TMPDIR/miniconda.sh" https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+#chmod +x "$TMPDIR/miniconda.sh"
+#cd "$TMPDIR" || exit
+#./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
+#"$MINICONDA_PATH"/bin/conda update -y -n base conda
+#"$MINICONDA_PATH"/bin/conda install -y --override-channels -c conda-forge nodejs jupyterlab
+#"$MINICONDA_PATH"/bin/jupyter lab build
+#chmod -R ug+rw "$MINICONDA_PATH"
+
+rm -rf /g/data/v10/private/miniconda3-new
 curl -o "$TMPDIR/miniconda.sh" https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 chmod +x "$TMPDIR/miniconda.sh"
 cd "$TMPDIR" || exit
-./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
-"$MINICONDA_PATH"/bin/conda update -y -n base --all
-"$MINICONDA_PATH"/bin/conda install -y --override-channels -c conda-forge pip tar
-chmod -R ug+rw "$MINICONDA_PATH"
+./miniconda.sh -b -f -u -p /g/data/v10/private/miniconda3-new
+/g/data/v10/private/miniconda3-new/bin/conda install -y --override-channels -c conda-forge nodejs jupyterlab=0.34.2
+/g/data/v10/private/miniconda3-new/bin/jupyter lab build
+#/g/data/v10/private/miniconda3/bin/conda update -y -n base conda


### PR DESCRIPTION
**Reason for this pull request**
When `rasterstats `and `jupyter `lab extension modules were added to the `environment.yaml` file, `dea-env` build fails while creating a new `dea `build or sometimes some of the python packages would downgrade. 

**Proposed solution**
1) Update `reinstall_miniconda` file to check if `nvm `package is installed (if not install the package). This is to ensure that `jupyter` `lab` extension modules are installed and build correctly.
2) Add `rasterstats` to the `environment.yaml` file and add dependencies with the latest version.
3) Add dependencies for `jupyter` `lab` issue and improve logging.
4) Redirect the `subprocess` output to a log file and store the log file in the build directory.
5) Update user instructions in `README.md` file for building dea environment and dea module.

- [x] Tested the new changes manually and is working fine