### PR TITLE
Increase cron timeout to 5 minutes from 2 minutes

### DIFF
--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -31,13 +31,13 @@ custom:
 provider:
   name: aws
   runtime: nodejs6.10
-  timeout: 120 # 2 minutes. Default is 6 seconds
+  timeout: 300 # 5 minutes. Default is 6 seconds
   profile: ${self:custom.profiles.${self:custom.Stage}}
   environment:
     hostkey: 'orchestrator.raijin.users.default.host'
     userkey: 'orchestrator.raijin.users.default.user'
     pkey: 'orchestrator.raijin.users.default.pkey'
-    DEA_MODULE: dea/20180926
+    DEA_MODULE: dea/20180928
     PROJECT: v10
     QUEUE: normal
   region: ap-southeast-2


### PR DESCRIPTION
**Reason for this pull request**
On failure, Lambda functions being invoked asynchronously are retried at least 3 times, after which the event may be rejected. Timeout set in the `serverless.yml` file was 2 minutes. During each retries `lambda` function was executed and this was causing `AWS` `lambda` trigger multiple times.

**Proposed workaround**
Increase the timeout in the `serverless.yml` file to 5 minutes (max) from 2 minutes.
