### PR TITLE
Make stats qsub job run after wofs job

### DIFF
--- a/raijin_scripts/test_deaenv/run
+++ b/raijin_scripts/test_deaenv/run
@@ -239,8 +239,6 @@ do
     echo "Running:
     qsub -V -W depend=afterany:$pbs_jobs -v WORKDIR=$WORKDIR,MUT=$MODULE,PRODUCT=$i,CONFIGFILE=$CONFIGFILE,DBNAME=$databasename,TESTDIR=$TESTDIR, $TESTDIR/dea_testscripts/datacube-stats.sh"
 
-    stats_job="$(qsub -V -W depend=afterany:"$pbs_jobs" -v WORKDIR="$WORKDIR",MUT="$MODULE",PRODUCT="$i",CONFIGFILE="$CONFIGFILE",DBNAME="$databasename",TESTDIR="$TESTDIR", "$TESTDIR"/dea_testscripts/datacube-stats.sh)"
-    pbs_jobs="$stats_job"
-    echo "$pbs_jobs"
+    qsub -V -W depend=afterany:"$pbs_jobs" -v WORKDIR="$WORKDIR",MUT="$MODULE",PRODUCT="$i",CONFIGFILE="$CONFIGFILE",DBNAME="$databasename",TESTDIR="$TESTDIR", "$TESTDIR"/dea_testscripts/datacube-stats.sh
     echo ""
 done


### PR DESCRIPTION
**Reason for this pull request**
Qsub job for `stats` was dependent on every `stats` config file. This was causing the stats testing wait for long time (due to normal queue qsub job).

**Proposed solution**
Make `stats` pbs job run after `wofs` job is completed.