### PR TITLE
Handle comments within pgpass file

### DIFF
--- a/raijin_scripts/deploy/dea/datacube-ensure-user.py
+++ b/raijin_scripts/deploy/dea/datacube-ensure-user.py
@@ -79,6 +79,7 @@ def find_credentials(pgpass, host, dbcreds):
     else:
         with pgpass.open() as src:
             for line in src:
+                # Ignore comments and empty lines
                 if not line.startswith('#') and line.strip():
                     creds = DBCreds(*line.strip().split(':'))
                     if creds.host == host and creds.username == dbcreds.username:

--- a/raijin_scripts/deploy/dea/datacube-ensure-user.py
+++ b/raijin_scripts/deploy/dea/datacube-ensure-user.py
@@ -79,7 +79,7 @@ def find_credentials(pgpass, host, dbcreds):
     else:
         with pgpass.open() as src:
             for line in src:
-                if line.partition('#')[0].strip():
+                if not line.startswith('#') and line.strip():
                     creds = DBCreds(*line.strip().split(':'))
                     if creds.host == host and creds.username == dbcreds.username:
                         # Production database credentials exists

--- a/raijin_scripts/deploy/dea/datacube-ensure-user.py
+++ b/raijin_scripts/deploy/dea/datacube-ensure-user.py
@@ -80,7 +80,7 @@ def find_credentials(pgpass, host, dbcreds):
         with pgpass.open() as src:
             for line in src:
                 # Ignore comments and empty lines
-                if not line.startswith('#') and line.strip():
+                if not line.strip().startswith('#') and line.strip():
                     creds = DBCreds(*line.strip().split(':'))
                     if creds.host == host and creds.username == dbcreds.username:
                         # Production database credentials exists

--- a/raijin_scripts/deploy/dea/datacube-ensure-user.py
+++ b/raijin_scripts/deploy/dea/datacube-ensure-user.py
@@ -326,12 +326,15 @@ def test_against_emptylines_in_pgpass(tmpdir):
 
 def test_against_comment_in_pgpass(tmpdir):
     existing_pgpass = dedent('''
-            # testing comments #
+            # test comment 1 #
             130.56.244.105:5432:*:foo_user:asdf
 
-            # testing comments
+            # test comments 2
             agdc-db.nci.org.au:*:*:foo_user:asdf
+
+            # 'test comments 3'
             agdcdev-db.nci.org.au:*:*:foo_user:asdf
+
             agdcstaging-db.nci.org.au:*:*:foo_user:asdf
 
             ''')


### PR DESCRIPTION
**Reason for pull request**
Comments within the `pgpass` file would break the existing logic within `datacube-ensure-user.py` file.

**Proposed solution**
1) Update the code to handle comments within `pgpass` file.
2) Remove logging of connection successful status when user loads the `dea` module.

- [x] Tests added