### PR TITLE
Add dependencies (xgboost and joblib)

### DIFF
--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -400,6 +400,10 @@ def main(config_path):
         LOG.info(f'Run regression testing on new DEA Module (%r) ', dea_module)
         LOG.info('*'*80)
         run_command(f'sh {script_dir}/{test_script} --deamodule {dea_module} --testdir {script_dir}')
+    else:
+        LOG.info('List installed python dependencies and their versions:')
+        module_path = variables['module_path']
+        run_command(f'{module_path}/bin/pip freeze')
 
     shutil.move(ospath + '/' + LOG_NAME, variables['module_path'] + '/' + LOG_NAME)
 

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -40,7 +40,6 @@ dependencies:
 - gettext
 - giflib
 - glib
-- glueviz
 - glue-geospatial
 - graphviz # This is only graphviz itself, not the python bindings. The latter are in the pip section.
 - hdf4
@@ -54,6 +53,7 @@ dependencies:
 - ipympl
 - ipywidgets
 - jmespath
+- joblib
 - jpeg
 - jplephem
 - json-c
@@ -148,6 +148,7 @@ dependencies:
 - widgetsnbextension
 - xarray
 - xerces-c
+- xgboost
 - xorg-kbproto
 - xorg-libice
 - xorg-libsm

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -8,7 +8,7 @@ chmod +x "$TMPDIR/miniconda.sh"
 cd "$TMPDIR" || exit
 ./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
 "$MINICONDA_PATH"/bin/conda update -y -c conda-forge --all
-"$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip
+"$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip glueviz
 
 if [ ! -d "$HOME"/.nvm ]
 then


### PR DESCRIPTION
Add `xgboost` and `joblib` dependencies to the python `dea` environment module. Also, log the conda package versions packaged within the `dea-env` module in the log file.