### PR TITLE
Add email monitoring for pbs jobs

### DIFF
--- a/raijin_scripts/execute_sync/run
+++ b/raijin_scripts/execute_sync/run
@@ -105,5 +105,5 @@ echo "Starting Sync process......"
 ##################################################################################################
 # Run dea-sync process
 ##################################################################################################
-qsub -V -N dea-sync -q "${QUEUE}" -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" -o "$WORKDIR" -e "$WORKDIR" -- dea-sync -vvv --cache-folder "$WORKDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing ${PATHS_TO_PROCESS[@]}
+qsub -V -N dea-sync -q "${QUEUE}" -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -m ae -M nci.monitor@dea.ga.gov.au -P "${PROJECT}" -o "$WORKDIR" -e "$WORKDIR" -- dea-sync -vvv --cache-folder "$WORKDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing ${PATHS_TO_PROCESS[@]}
 EOF

--- a/raijin_scripts/test_deaenv/dea_testscripts/datacube-fc.sh
+++ b/raijin_scripts/test_deaenv/dea_testscripts/datacube-fc.sh
@@ -78,9 +78,9 @@ datacube-fc list
 datacube-fc ensure-products --app-config "$WORKDIR"/fc_configfiles/ls8_fc_albers.yaml -C "$CONFIGFILE" -vvv --dry-run
 datacube-fc ensure-products --app-config "$WORKDIR"/fc_configfiles/ls8_fc_albers.yaml -C "$CONFIGFILE" -vvv
 
-datacube-fc submit --app-config "$WORKDIR"/fc_configfiles/ls8_fc_albers.yaml -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR" --no-qsub
-datacube-fc submit --app-config "$WORKDIR"/fc_configfiles/ls8_fc_albers.yaml -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR" --dry-run
-datacube-fc submit --app-config "$WORKDIR"/fc_configfiles/ls8_fc_albers.yaml -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR"
+datacube-fc submit --app-config "$WORKDIR"/fc_configfiles/ls8_fc_albers.yaml -M santosh.mohan@ga.gov.au -m ae -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR" --no-qsub
+datacube-fc submit --app-config "$WORKDIR"/fc_configfiles/ls8_fc_albers.yaml -M santosh.mohan@ga.gov.au -m ae -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR" --dry-run
+datacube-fc submit --app-config "$WORKDIR"/fc_configfiles/ls8_fc_albers.yaml -M santosh.mohan@ga.gov.au -m ae -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR"
 
 sleep 5s  
 

--- a/raijin_scripts/test_deaenv/dea_testscripts/datacube-stats.sh
+++ b/raijin_scripts/test_deaenv/dea_testscripts/datacube-stats.sh
@@ -15,6 +15,9 @@
 #PBS -l ncpus=16
 #PBS -l walltime=10:00:00
 
+#PBS -M santosh.mohan@ga.gov.au
+#PBS -m ae
+
 #PBS -N dc-stats
 
 echo "

--- a/raijin_scripts/test_deaenv/dea_testscripts/datacube-wofs.sh
+++ b/raijin_scripts/test_deaenv/dea_testscripts/datacube-wofs.sh
@@ -78,9 +78,9 @@ datacube-wofs list
 datacube-wofs ensure-products --app-config "$WORKDIR"/wofs_configfiles/wofs_albers.yaml -C "$CONFIGFILE" -vvv --dry-run
 datacube-wofs ensure-products --app-config "$WORKDIR"/wofs_configfiles/wofs_albers.yaml -C "$CONFIGFILE" -vvv
 
-datacube-wofs submit --app-config "$WORKDIR"/wofs_configfiles/wofs_albers.yaml -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR" --no-qsub
-datacube-wofs submit --app-config "$WORKDIR"/wofs_configfiles/wofs_albers.yaml -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR" --dry-run
-datacube-wofs submit --app-config "$WORKDIR"/wofs_configfiles/wofs_albers.yaml -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR"
+datacube-wofs submit --app-config "$WORKDIR"/wofs_configfiles/wofs_albers.yaml -M santosh.mohan@ga.gov.au -m ae -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR" --no-qsub
+datacube-wofs submit --app-config "$WORKDIR"/wofs_configfiles/wofs_albers.yaml -M santosh.mohan@ga.gov.au -m ae -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR" --dry-run
+datacube-wofs submit --app-config "$WORKDIR"/wofs_configfiles/wofs_albers.yaml -M santosh.mohan@ga.gov.au -m ae -P u46 -q express -C "$CONFIGFILE" -vvv --year "$YEAR" --tag "$YEAR"
 
 sleep 5s  
 

--- a/raijin_scripts/test_deaenv/dea_testscripts/dea-submit-ingest.sh
+++ b/raijin_scripts/test_deaenv/dea_testscripts/dea-submit-ingest.sh
@@ -74,4 +74,4 @@ echo "**********************************************************************"
 echo ""
 
 cd "$INGESTDIR" || exit 0
-yes 2>/dev/null | dea-submit-ingest qsub --project u46 --queue express -n 5 -t 10 -m a -M santosh.mohan@ga.gov.au -W umask=33 --name "$JOB_NAME" -c "$WORKDIR"/ingest_configfiles/"${PRODUCT}".yaml -C "$CONFIGFILE" --allow-product-changes "${PRODUCT}" "${YEAR}"
+yes 2>/dev/null | dea-submit-ingest qsub --project u46 --queue express -n 5 -t 10 -m ae -M santosh.mohan@ga.gov.au -W umask=33 --name "$JOB_NAME" -c "$WORKDIR"/ingest_configfiles/"${PRODUCT}".yaml -C "$CONFIGFILE" --allow-product-changes "${PRODUCT}" "${YEAR}"

--- a/raijin_scripts/test_deaenv/dea_testscripts/dea-sync.sh
+++ b/raijin_scripts/test_deaenv/dea_testscripts/dea-sync.sh
@@ -74,4 +74,4 @@ fi
 
 cd "$SYNCDIR" || exit 0
 mkdir -p "$SYNCDIR"/cache
-qsub -V -W block=true -N dea-sync -q express -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -P u46 -- dea-sync -vvv --cache-folder "$SYNCDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing "$PATH_TO_PROCESS"
+qsub -V -W block=true -N dea-sync -q express -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -m ae -M santosh.mohan@ga.gov.au -P u46 -- dea-sync -vvv --cache-folder "$SYNCDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing "$PATH_TO_PROCESS"

--- a/raijin_scripts/test_deaenv/dea_testscripts/pbs_nbconvert_script.sh
+++ b/raijin_scripts/test_deaenv/dea_testscripts/pbs_nbconvert_script.sh
@@ -15,6 +15,9 @@
 #PBS -l ncpus=16
 #PBS -l walltime=05:00:00
 
+#PBS -M santosh.mohan@ga.gov.au
+#PBS -m ae
+
 #PBS -N Test_NBConvert
 
 ##########################################


### PR DESCRIPTION
**Reason for this pull request**
Email notification of `pbs` job that `successfully executed` or `failed to execute` or `aborted`, are missing for `dea-sync` script and `test_deaenv` scripts.

**Proposed solutions**
- Update the following scripts to notify `success`/`failure`/`aborted` status via email:
    - `raijin_scripts/execute_sync/run`
    - `datacube-stats.sh`
    - `dea-sync.sh`
    - `pbs_nbconvert_script.sh`