### PR TITLE
Make stats test run after wofs tests

### DIFF
--- a/raijin_scripts/test_deaenv/dea_testscripts/dea-sync.sh
+++ b/raijin_scripts/test_deaenv/dea_testscripts/dea-sync.sh
@@ -73,5 +73,5 @@ if [ "$TRASH_ARC" == yes ]; then
 fi
 
 cd "$SYNCDIR" || exit 0
-mkdir -p "$SYNCDIR"/cache
-qsub -V -W block=true -N dea-sync -q express -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -m ae -M santosh.mohan@ga.gov.au -P u46 -- dea-sync -vvv --cache-folder "$SYNCDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing "$PATH_TO_PROCESS"
+mkdir -p "$SYNCDIR/cache_$RANDOM"
+qsub -V -W block=true -N dea-sync -q express -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -m ae -M santosh.mohan@ga.gov.au -P u46 -- dea-sync -vvv --cache-folder "$SYNCDIR/cache_$RANDOM" -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing "$PATH_TO_PROCESS"

--- a/raijin_scripts/test_deaenv/run
+++ b/raijin_scripts/test_deaenv/run
@@ -195,8 +195,8 @@ echo ""
 cd "$WORKDIR"/work/wofs || exit 0
 echo "Running:
 qsub -V -W depend=afterany:$fc_jobs -v WORKDIR=$WORKDIR,MUT=$MODULE,YEAR=2018,CONFIGFILE=$CONFIGFILE,DBNAME=$databasename,TESTDIR=$TESTDIR, $TESTDIR/dea_testscripts/datacube-wofs.sh"
-
-qsub -V -W depend=afterany:"$fc_jobs" -v WORKDIR="$WORKDIR",MUT="$MODULE",YEAR=2018,CONFIGFILE="$CONFIGFILE",DBNAME="$databasename",TESTDIR="$TESTDIR", "$TESTDIR"/dea_testscripts/datacube-wofs.sh
+wofs_job="$(qsub -V -W depend=afterany:"$fc_jobs" -v WORKDIR="$WORKDIR",MUT="$MODULE",YEAR=2018,CONFIGFILE="$CONFIGFILE",DBNAME="$databasename",TESTDIR="$TESTDIR", "$TESTDIR"/dea_testscripts/datacube-wofs.sh)"
+echo "$wofs_job"
 echo ""
 
 echo "
@@ -230,15 +230,13 @@ declare -a stats_yaml_array=("item_10"
                              "fc_ls8_2018_none_shapefile"
                              "fc_ls8_2018_percentile_no_prov"
                              "fc_ls8_2018_percentile_no_prov_shapefile")
-# Fetch pbs job id's
-pbs_jobs=$( fetch_pbs_job_ids )
 
 cd "$WORKDIR"/work/stats || exit 0
 for i in "${stats_yaml_array[@]}"
 do 
     echo "Running:
-    qsub -V -W depend=afterany:$pbs_jobs -v WORKDIR=$WORKDIR,MUT=$MODULE,PRODUCT=$i,CONFIGFILE=$CONFIGFILE,DBNAME=$databasename,TESTDIR=$TESTDIR, $TESTDIR/dea_testscripts/datacube-stats.sh"
+    qsub -V -W depend=afterany:$wofs_job -v WORKDIR=$WORKDIR,MUT=$MODULE,PRODUCT=$i,CONFIGFILE=$CONFIGFILE,DBNAME=$databasename,TESTDIR=$TESTDIR, $TESTDIR/dea_testscripts/datacube-stats.sh"
 
-    qsub -V -W depend=afterany:"$pbs_jobs" -v WORKDIR="$WORKDIR",MUT="$MODULE",PRODUCT="$i",CONFIGFILE="$CONFIGFILE",DBNAME="$databasename",TESTDIR="$TESTDIR", "$TESTDIR"/dea_testscripts/datacube-stats.sh
+    qsub -V -W depend=afterany:"$wofs_job" -v WORKDIR="$WORKDIR",MUT="$MODULE",PRODUCT="$i",CONFIGFILE="$CONFIGFILE",DBNAME="$databasename",TESTDIR="$TESTDIR", "$TESTDIR"/dea_testscripts/datacube-stats.sh
     echo ""
 done


### PR DESCRIPTION
**Reason for this pull request**
To speedup the test execution, start `stats` tests after `wofs` scripts have completed execution. Existing script would wait for long time before all the test scripts have completed the test runs.

**Proposed solution**
Store `wofs` `qsub` job id to a variable and use this as a dependency condition for `qsub` job scheduling. Also, rename `sync` cache folder to be unique to avoid duplicates.