### PR TITLE
Fix inconsistent dependency issue and add python packages

### DIFF
--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -183,6 +183,7 @@ dependencies:
   - modernize
   - mypy
   - opencv-python
+  - parse
   - perf
   - pudb
   - pydash

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -88,6 +88,7 @@ dependencies:
 - mkl_fft
 - mkl_random
 - mock
+- mpi4py
 - munch
 - nb_conda_kernels
 - netcdf4

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -168,6 +168,7 @@ dependencies:
   - awscli
   - boltons
   - celery
+  - checksumdir
   - ciso8601
   - click-datetime
   - DAWG

--- a/raijin_scripts/deploy/dea-env/modulefile.template
+++ b/raijin_scripts/deploy/dea-env/modulefile.template
@@ -16,19 +16,27 @@ set base          ${module_path}
 
 module-whatis   "${module_description} ${module_version}"
 
-if {[module-info mode load] && [info exists env(PYTHONPATH)] && $$env(PYTHONPATH) != ""} {
-        puts stderr "Warning: PYTHONPATH is $$env(PYTHONPATH)"
-        puts stderr "Try unloading all python modules if you experience any issues."
-}
-
 # Enable segfault tracebacks in py3. https://docs.python.org/3/library/faulthandler.html
 setenv PYTHONFAULTHANDLER 1
 
-prepend-path PATH ${module_path}/bin
+# Set PYTHONUSERBASE based on the version of dea-env module.
+# This allows users to install python packages with "pip install --user <package>",
+setenv PYTHONUSERBASE ~/.digitalearthau/${module_version}/local
 setenv GDAL_DATA ${module_path}/share/gdal
 
-# Disable loading modules and .pth files from ~/.local/lib/python3.6/...
-# This allows users to install python packages with "pip install --user <package>",
-# while still meaning that a new module release will have a clean user environment.
-setenv PYTHONUSERBASE ~/.digitalearthau/${module_version}/local
-prepend-path PATH ~/.digitalearthau/${module_version}/local/bin
+if {[module-info mode load] && [info exists env(PYTHONPATH)] && $$env(PYTHONPATH) != ""} {
+        puts stderr "Warning: PYTHONPATH is $$env(PYTHONPATH)"
+        puts stderr "Unload all python modules, if you experience any issues."
+} else {
+        # Prepend only if we have new dea-env module
+        prepend-path PATH ${module_path}/bin
+
+        # Set python path to point to the dea-env path
+        setenv PYTHONPATH ${python_path}
+
+        # To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
+        # variables to point to a directory based on the Environment Module version which is loaded so that extra
+        # packages must be re-installed when a new dea-env module is released
+        prepend-path PATH ~/.digitalearthau/${module_version}/local/bin
+        prepend-path PYTHONPATH ~/.digitalearthau/${module_version}/local
+}

--- a/raijin_scripts/deploy/dea-env/modulefile.template
+++ b/raijin_scripts/deploy/dea-env/modulefile.template
@@ -28,13 +28,12 @@ if {[module-info mode load] && [info exists env(PYTHONPATH)] && $$env(PYTHONPATH
         puts stderr "Warning: ${module_name}/${module_version} exists in the python env ($$env(PYTHONPATH))"
         puts stderr "Unload all python modules, if you experience any issues."
 } else {
-        # Prepend only if we have new dea-env module
-        prepend-path PATH ${module_path}/bin
-
         # Set python path to point to the dea-env path
         setenv PYTHONPATH ${python_path}
 
         prepend-path PYTHONPATH ~/.digitalearthau/${module_name}/${module_version}/local
+
+        prepend-path PATH ${module_path}/bin
 
         # To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
         # variables to point to a directory based on the Environment Module version which is loaded so that extra

--- a/raijin_scripts/deploy/dea-env/modulefile.template
+++ b/raijin_scripts/deploy/dea-env/modulefile.template
@@ -33,4 +33,11 @@ if {[module-info mode load] && [info exists env(PYTHONPATH)] && $$env(PYTHONPATH
 
         # Set python path to point to the dea-env path
         setenv PYTHONPATH ${python_path}
+
+        prepend-path PYTHONPATH ~/.digitalearthau/${module_name}/${module_version}/local
+
+        # To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
+        # variables to point to a directory based on the Environment Module version which is loaded so that extra
+        # packages must be re-installed when a new dea-env module is released
+        prepend-path PATH ~/.digitalearthau/${module_name}/${module_version}/local/bin
 }

--- a/raijin_scripts/deploy/dea-env/modulefile.template
+++ b/raijin_scripts/deploy/dea-env/modulefile.template
@@ -21,11 +21,11 @@ setenv PYTHONFAULTHANDLER 1
 
 # Set PYTHONUSERBASE based on the version of dea-env module.
 # This allows users to install python packages with "pip install --user <package>",
-setenv PYTHONUSERBASE ~/.digitalearthau/${module_version}/local
+setenv PYTHONUSERBASE ~/.digitalearthau/${module_name}/${module_version}/local
 setenv GDAL_DATA ${module_path}/share/gdal
 
 if {[module-info mode load] && [info exists env(PYTHONPATH)] && $$env(PYTHONPATH) != ""} {
-        puts stderr "Warning: PYTHONPATH is $$env(PYTHONPATH)"
+        puts stderr "Warning: ${module_name}/${module_version} exists in the python env ($$env(PYTHONPATH))"
         puts stderr "Unload all python modules, if you experience any issues."
 } else {
         # Prepend only if we have new dea-env module
@@ -33,10 +33,4 @@ if {[module-info mode load] && [info exists env(PYTHONPATH)] && $$env(PYTHONPATH
 
         # Set python path to point to the dea-env path
         setenv PYTHONPATH ${python_path}
-
-        # To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
-        # variables to point to a directory based on the Environment Module version which is loaded so that extra
-        # packages must be re-installed when a new dea-env module is released
-        prepend-path PATH ~/.digitalearthau/${module_version}/local/bin
-        prepend-path PYTHONPATH ~/.digitalearthau/${module_version}/local
 }

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -3,12 +3,13 @@ variables:
   module_description: DEA Environment Module
   modules_dir: "/g/data/v10/public/modules"
   conda_path: "/g/data/v10/private/miniconda3-new/bin/conda"
-  # module_version: This is filled in automatically
+  python_version: 3.6
 
 # These templated variables are filled and included in the available variables used
 # in template files and configuration sections below
 templated_variables:
   module_path: "{modules_dir}/{module_name}/{module_version}"
+  python_path: "{modules_dir}/{module_name}/{module_version}/lib/python{python_version}/site-packages/"
 
 install_conda_packages: environment.yaml
 

--- a/raijin_scripts/deploy/dea/modulefile.template
+++ b/raijin_scripts/deploy/dea/modulefile.template
@@ -27,15 +27,16 @@ setenv LANG C.UTF-8
 if {[module-info mode load] && [is-loaded ${module_name}/${module_version}]} {
         puts stderr "Warning: ${module_name}/${module_version} exists in the python env ($$env(PYTHONPATH))"
 } else {
-        # Prepend only if we have new dea-env module
         prepend-path PATH ${module_path}/bin
-        prepend-path PYTHONPATH ${python_path}
-        prepend-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
 
         # To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
         # variables to point to a directory based on the Environment Module version which is loaded so that extra
         # packages must be re-installed when a new dea-env module is released
         prepend-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
+
+        prepend-path PYTHONPATH ${python_path}
+        prepend-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
+
 }
 
 #############################################################

--- a/raijin_scripts/deploy/dea/modulefile.template
+++ b/raijin_scripts/deploy/dea/modulefile.template
@@ -20,10 +20,23 @@ module load udunits
 
 module load ${fixed_dea_env}
 
-prepend-path PATH ${module_path}/bin
 setenv DATACUBE_CONFIG_PATH ${module_path}/datacube.conf
 setenv LC_ALL en_AU.utf8
 setenv LANG C.UTF-8
+
+if {[module-info mode load] && [is-loaded ${module_name}/${module_version}]} {
+        puts stderr "Warning: ${module_name}/${module_version} exists in the python env ($$env(PYTHONPATH))"
+} else {
+        # Prepend only if we have new dea-env module
+        prepend-path PATH ${module_path}/bin
+        prepend-path PYTHONPATH ${python_path}
+        prepend-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
+
+        # To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
+        # variables to point to a directory based on the Environment Module version which is loaded so that extra
+        # packages must be re-installed when a new dea-env module is released
+        prepend-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
+}
 
 #############################################################
 # When loading, ensure a database username has been created

--- a/raijin_scripts/deploy/dea/modulefile.template
+++ b/raijin_scripts/deploy/dea/modulefile.template
@@ -20,12 +20,8 @@ module load udunits
 
 module load ${fixed_dea_env}
 
-prepend-path PYTHONPATH ${python_path}
-prepend-path PYTHONPATH ~/.digitalearthau/${module_version}/local
 prepend-path PATH ${module_path}/bin
-
 setenv DATACUBE_CONFIG_PATH ${module_path}/datacube.conf
-
 setenv LC_ALL en_AU.utf8
 setenv LANG C.UTF-8
 

--- a/raijin_scripts/deploy/dea/modulespec.yaml
+++ b/raijin_scripts/deploy/dea/modulespec.yaml
@@ -4,11 +4,9 @@ variables:
   modules_base: "/g/data/v10/public/modules"
   dbhost: 130.56.244.105
   dbport: 6432
-  python_version: 3.6
 
 templated_variables:
   module_path: "{modules_base}/{module_name}/{module_version}"
-  python_path: "{modules_base}/{module_name}/{module_version}/lib/python{python_version}/site-packages/"
   dea_module: "{module_name}/{module_version}"
 
 stable_module_deps:

--- a/raijin_scripts/deploy/dea/modulespec.yaml
+++ b/raijin_scripts/deploy/dea/modulespec.yaml
@@ -4,9 +4,11 @@ variables:
   modules_base: "/g/data/v10/public/modules"
   dbhost: 130.56.244.105
   dbport: 6432
+  python_version: 3.6
 
 templated_variables:
   module_path: "{modules_base}/{module_name}/{module_version}"
+  python_path: "{modules_base}/{module_name}/{module_version}/lib/python{python_version}/site-packages/"
   dea_module: "{module_name}/{module_version}"
 
 stable_module_deps:

--- a/raijin_scripts/test_deaenv/dea_testscripts/dea-sync.sh
+++ b/raijin_scripts/test_deaenv/dea_testscripts/dea-sync.sh
@@ -73,5 +73,5 @@ if [ "$TRASH_ARC" == yes ]; then
 fi
 
 cd "$SYNCDIR" || exit 0
-mkdir -p "$SYNCDIR"/cache
-qsub -V -W block=true -N dea-sync -q express -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -m ae -M santosh.mohan@ga.gov.au -P u46 -- dea-sync -vvv --cache-folder "$SYNCDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing "$PATH_TO_PROCESS"
+mkdir -p "$SYNCDIR/cache_$RANDOM"
+qsub -V -W block=true -N dea-sync -q express -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -m ae -M santosh.mohan@ga.gov.au -P u46 -- dea-sync -vvv --cache-folder "$SYNCDIR/cache_$RANDOM" -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing "$PATH_TO_PROCESS"

--- a/raijin_scripts/test_deaenv/run
+++ b/raijin_scripts/test_deaenv/run
@@ -195,8 +195,8 @@ echo ""
 cd "$WORKDIR"/work/wofs || exit 0
 echo "Running:
 qsub -V -W depend=afterany:$fc_jobs -v WORKDIR=$WORKDIR,MUT=$MODULE,YEAR=2018,CONFIGFILE=$CONFIGFILE,DBNAME=$databasename,TESTDIR=$TESTDIR, $TESTDIR/dea_testscripts/datacube-wofs.sh"
-
-qsub -V -W depend=afterany:"$fc_jobs" -v WORKDIR="$WORKDIR",MUT="$MODULE",YEAR=2018,CONFIGFILE="$CONFIGFILE",DBNAME="$databasename",TESTDIR="$TESTDIR", "$TESTDIR"/dea_testscripts/datacube-wofs.sh
+wofs_job="$(qsub -V -W depend=afterany:"$fc_jobs" -v WORKDIR="$WORKDIR",MUT="$MODULE",YEAR=2018,CONFIGFILE="$CONFIGFILE",DBNAME="$databasename",TESTDIR="$TESTDIR", "$TESTDIR"/dea_testscripts/datacube-wofs.sh)"
+echo "$wofs_job"
 echo ""
 
 echo "
@@ -230,15 +230,13 @@ declare -a stats_yaml_array=("item_10"
                              "fc_ls8_2018_none_shapefile"
                              "fc_ls8_2018_percentile_no_prov"
                              "fc_ls8_2018_percentile_no_prov_shapefile")
-# Fetch pbs job id's
-pbs_jobs=$( fetch_pbs_job_ids )
 
 cd "$WORKDIR"/work/stats || exit 0
 for i in "${stats_yaml_array[@]}"
 do 
     echo "Running:
-    qsub -V -W depend=afterany:$pbs_jobs -v WORKDIR=$WORKDIR,MUT=$MODULE,PRODUCT=$i,CONFIGFILE=$CONFIGFILE,DBNAME=$databasename,TESTDIR=$TESTDIR, $TESTDIR/dea_testscripts/datacube-stats.sh"
+    qsub -V -W depend=afterany:$wofs_job -v WORKDIR=$WORKDIR,MUT=$MODULE,PRODUCT=$i,CONFIGFILE=$CONFIGFILE,DBNAME=$databasename,TESTDIR=$TESTDIR, $TESTDIR/dea_testscripts/datacube-stats.sh"
 
-    qsub -V -W depend=afterany:"$pbs_jobs" -v WORKDIR="$WORKDIR",MUT="$MODULE",PRODUCT="$i",CONFIGFILE="$CONFIGFILE",DBNAME="$databasename",TESTDIR="$TESTDIR", "$TESTDIR"/dea_testscripts/datacube-stats.sh
+    qsub -V -W depend=afterany:"$wofs_job" -v WORKDIR="$WORKDIR",MUT="$MODULE",PRODUCT="$i",CONFIGFILE="$CONFIGFILE",DBNAME="$databasename",TESTDIR="$TESTDIR", "$TESTDIR"/dea_testscripts/datacube-stats.sh
     echo ""
 done


### PR DESCRIPTION
## Reason for this pull request
`PYTHONUSERBASE`, `PATH`, or `PYTHONPATH` are being set to the version of `dea` module that should have been set based on the version of `dea-env` module. This would attempt to install the extra python packages into the `dea` module path instead of their `home` directory. Also, local `home` directory name is referring to `dea` module instead of `dea-env` module.

## Proposed solution
- Update module template files to fix `path` issue.
- Add the following new python packages to the `dea-env` module.
    - `mpi4py`
    - `rasterstats`
    - `keras`
    - `rios`
    - `checksumdir`
    - `parse`

- [x] Closes `digitalearthau` `PR's` ( [#170](https://github.com/GeoscienceAustralia/digitalearthau/issues/170),  [#171,](https://github.com/GeoscienceAustralia/digitalearthau/issues/171) [#118,](https://github.com/GeoscienceAustralia/digitalearthau/issues/118) [#117,](https://github.com/GeoscienceAustralia/digitalearthau/issues/117) [#121,](https://github.com/GeoscienceAustralia/digitalearthau/issues/121) and [#173)](https://github.com/GeoscienceAustralia/digitalearthau/issues/173)