### PR TITLE
Set HOME directory at the top of the PATH list

### DIFF
--- a/raijin_scripts/deploy/dea-env/modulefile.template
+++ b/raijin_scripts/deploy/dea-env/modulefile.template
@@ -27,16 +27,21 @@ setenv GDAL_DATA ${module_path}/share/gdal
 if {[module-info mode load] && [info exists env(PYTHONPATH)] && $$env(PYTHONPATH) != ""} {
         puts stderr "Warning: ${module_name}/${module_version} exists in the python env ($$env(PYTHONPATH))"
         puts stderr "Unload all python modules, if you experience any issues."
-} else {
-        # Set python path to point to the dea-env path
-        setenv PYTHONPATH ${python_path}
-
-        prepend-path PYTHONPATH ~/.digitalearthau/${module_name}/${module_version}/local
-
-        prepend-path PATH ${module_path}/bin
-
-        # To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
-        # variables to point to a directory based on the Environment Module version which is loaded so that extra
-        # packages must be re-installed when a new dea-env module is released
-        prepend-path PATH ~/.digitalearthau/${module_name}/${module_version}/local/bin
 }
+
+# Set python path to point to the dea-env path
+setenv PYTHONPATH ${python_path}
+
+prepend-path PYTHONPATH ~/.digitalearthau/${module_name}/${module_version}/local
+
+# Remove duplicate entries for module path dir and prepend again
+remove-path PATH ${module_path}/bin
+prepend-path PATH ${module_path}/bin
+
+# To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
+# variables to point to a directory based on the Environment Module version which is loaded so that extra
+# packages must be re-installed when a new dea-env module is released
+# Remove duplicate entries for HOME dir and prepend again
+remove-path PATH ~/.digitalearthau/${module_name}/${module_version}/local/bin
+prepend-path PATH ~/.digitalearthau/${module_name}/${module_version}/local/bin
+

--- a/raijin_scripts/deploy/dea-env/modulefile.template
+++ b/raijin_scripts/deploy/dea-env/modulefile.template
@@ -32,7 +32,7 @@ if {[module-info mode load] && [info exists env(PYTHONPATH)] && $$env(PYTHONPATH
 # Set python path to point to the dea-env path
 setenv PYTHONPATH ${python_path}
 
-prepend-path PYTHONPATH ~/.digitalearthau/${module_name}/${module_version}/local
+prepend-path PYTHONPATH ~/.digitalearthau/${module_name}/${module_version}/local/lib/python3.6/site-packages
 
 # Remove duplicate entries for module path dir and prepend again
 remove-path PATH ${module_path}/bin

--- a/raijin_scripts/deploy/dea/modulefile.template
+++ b/raijin_scripts/deploy/dea/modulefile.template
@@ -27,16 +27,19 @@ setenv LANG C.UTF-8
 if {[module-info mode load] && [is-loaded ${module_name}/${module_version}]} {
         puts stderr "Warning: ${module_name}/${module_version} exists in the python env ($$env(PYTHONPATH))"
 } else {
-        prepend-path PATH ${module_path}/bin
-
         # To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
         # variables to point to a directory based on the Environment Module version which is loaded so that extra
         # packages must be re-installed when a new dea-env module is released
+        prepend-path PATH ${module_path}/bin
+        prepend-path PYTHONPATH ${python_path}
+
+        # Remove duplicate entries for HOME dir and prepend at the top
+        remove-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
         prepend-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
 
-        prepend-path PYTHONPATH ${python_path}
+        # Remove duplicate entries for HOME dir and prepend at the top
+        remove-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
         prepend-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
-
 }
 
 #############################################################

--- a/raijin_scripts/deploy/dea/modulefile.template
+++ b/raijin_scripts/deploy/dea/modulefile.template
@@ -26,21 +26,22 @@ setenv LANG C.UTF-8
 
 if {[module-info mode load] && [is-loaded ${module_name}/${module_version}]} {
         puts stderr "Warning: ${module_name}/${module_version} exists in the python env ($$env(PYTHONPATH))"
-} else {
-        # To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
-        # variables to point to a directory based on the Environment Module version which is loaded so that extra
-        # packages must be re-installed when a new dea-env module is released
-        prepend-path PATH ${module_path}/bin
-        prepend-path PYTHONPATH ${python_path}
-
-        # Remove duplicate entries for HOME dir and prepend at the top
-        remove-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
-        prepend-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
-
-        # Remove duplicate entries for HOME dir and prepend at the top
-        remove-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
-        prepend-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
 }
+
+# To avoid user packages conflicting with Environment Module packages, point the PYTHONUSERBASE and PATH
+# variables to point to a directory based on the Environment Module version which is loaded so that extra
+# packages must be re-installed when a new dea-env module is released
+prepend-path PATH ${module_path}/bin
+prepend-path PYTHONPATH ${python_path}
+
+# Remove duplicate entries for HOME dir and prepend at the top
+remove-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
+prepend-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
+
+# Remove duplicate entries for HOME dir and prepend at the top
+remove-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
+prepend-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
+
 
 #############################################################
 # When loading, ensure a database username has been created

--- a/raijin_scripts/deploy/dea/modulefile.template
+++ b/raijin_scripts/deploy/dea/modulefile.template
@@ -39,7 +39,7 @@ remove-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
 prepend-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
 
 # Remove duplicate entries for HOME dir and prepend at the top
-remove-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
+remove-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local/lib/python3.6/site-packages
 prepend-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
 
 

--- a/raijin_scripts/deploy/dea/modulefile.template
+++ b/raijin_scripts/deploy/dea/modulefile.template
@@ -40,7 +40,7 @@ prepend-path PATH ~/.digitalearthau/${fixed_dea_env}/local/bin
 
 # Remove duplicate entries for HOME dir and prepend at the top
 remove-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local/lib/python3.6/site-packages
-prepend-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local
+prepend-path PYTHONPATH ~/.digitalearthau/${fixed_dea_env}/local/lib/python3.6/site-packages
 
 
 #############################################################


### PR DESCRIPTION
## Reason for this pull request
Flexibility to just load `dea-env` and work with user installed python packages was not feasible in the earlier implementation. Need to allow user to load `dea-env` or `dea` and do a `pip install` to install custom packages is a likely use case.

## Proposed solution
- Remove duplicate entries of `HOME` directory in `PYTHONPATH` and `PATH` and prepend `HOME` directory at the top.