### PR TITLE
Automate database inconsistency checks

### DIFF
--- a/lambda_functions/execute_ssh_command_js/handler.js
+++ b/lambda_functions/execute_ssh_command_js/handler.js
@@ -61,8 +61,8 @@ exports.execute_ssh_command = (event, context, callback) => {
 
             let command = create_execution_string(event);
 
-	        ssh
-	           .exec(command, {
+            ssh
+               .exec(command, {
                      exit: (code, stdout, stderr) => {
                         if (code == 0) {
                                          console.log(`Executing: ${command}`);

--- a/lambda_functions/execute_ssh_command_js/handler.js
+++ b/lambda_functions/execute_ssh_command_js/handler.js
@@ -5,6 +5,10 @@ var _ = require('lodash');
 const AWS = require("aws-sdk");
 AWS.config.update({region: 'ap-southeast-2'});
 
+var nodemailer = require("nodemailer");
+var ses = new AWS.SES();
+var s3 = new AWS.S3();
+
 const ssm = new AWS.SSM();
 
 const hostkey = process.env.hostkey;
@@ -28,6 +32,11 @@ const pkey = process.env.pkey;
  *      'mycommand --arg1 myarg'
  */
 function create_execution_string(event) {
+    var compiled = _.template(process.env.cmd);
+    return compiled(event);
+}
+
+function create_email_body_string(event) {
     var compiled = _.template(process.env.cmd);
     return compiled(event);
 }
@@ -84,4 +93,46 @@ exports.execute_ssh_command = (event, context, callback) => {
                    fail: (err) => console.log(`Failed to connect to ${params[hostkey]}: ${err}`)
                });
         });
+};
+
+
+exports.email_notification = function (event, context, callback) {
+    var mailOptions = {
+        from: "nci.monitor@dea.ga.gov.au",
+        subject: "Erroneous datasets found in database (Reported by coherence tool)!",
+        html: `<p>You got a contact message from: <b>${event.emailAddress}</b></p>`,
+        to: "santosh.mohan@ga.gov.au",
+        attachments: [
+            {
+               filename: "erroneous_datasets.csv",
+               content: fileData.Body
+            }
+        ]
+    };
+
+    console.log('Creating SES transporter');
+    // create Nodemailer SES transporter
+    var transporter = nodemailer.createTransport({
+        SES: ses
+    });
+
+    let email_body = create_email_body_string(event);
+
+    // send email
+    transporter.sendMail(mailOptions, function (err, info) {
+        if (err) {
+            console.log("Error sending email");
+            callback(err);
+        } else {
+            console.log(`Email Content: ${email_body}`);
+            console.log("Email sent successfully");
+            callback();
+        }
+    });
+  })
+  .catch(function (error) {
+            console.log(error);
+            console.log('Error getting attachment from S3');
+            callback(err);
+  });
 };

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -255,9 +255,9 @@ functions:
           rate: cron(00 09 ? * * *) # Run every day, at 07:00 pm Canberra time
           enabled: false
           input:
-            timerange: 'time in 2018'
+            timerange: "'\''time in 2018'\''"
   execute_notify_on_error_ds:
-    handler: handler.execute_ssh_command
+    handler: handler.email_notification
     description: Upload csv file to S3 and send an email, if coherence tool detects bad datasets in the database
     environment:
       cmd: 'execute_notify_on_error_ds --dea-module ${self:provider.environment.DEA_MODULE}'

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -27,16 +27,6 @@ custom:
     s3Bucket:
       prod: "dea-lambda"
       dev: "dea-lambdas-dev"
-  s3Sync:
-    - bucketName: ${self:custom.CustEnv.s3Bucket.${self:custom.Stage}} # required
-      localDir: /g/data/v10/work/coherence/ # required
-
-resources:
-  Resources:
-    AssetsBucket:
-      Type: AWS::S3::Bucket
-      Properties:
-        BucketName: ${self:custom.CustEnv.s3Bucket.${self:custom.Stage}}
 
 provider:
   name: aws
@@ -262,7 +252,7 @@ functions:
                               --timerange <%= timerange %>'
     events:
       - schedule:
-          rate: cron(20 10 ? * * *) # Run every day, at 08:20 pm Canberra time
+          rate: cron(00 09 ? * * *) # Run every day, at 07:00 pm Canberra time
           enabled: false
           input:
             timerange: 'time in 2018'
@@ -273,7 +263,7 @@ functions:
       cmd: 'execute_notify_on_error_ds --dea-module ${self:provider.environment.DEA_MODULE}'
     events:
       - schedule:
-          rate: cron(20 10 ? * SUN *) # Run every Sunday, at 08:20 pm Canberra time
+          rate: cron(00 10 ? * * *) # Run every day, at 08:00 pm Canberra time
           enabled: false
   execute_clean:
     handler: handler.execute_ssh_command
@@ -286,7 +276,7 @@ functions:
                           --search-string <%= searchstr %>'
     events:
       - schedule:
-          rate: cron(20 10 ? * SUN *) # Run every Sunday, at 08:20 pm Canberra time
+          rate: cron(00 11 ? * SUN *) # Run every Sunday, at 09:00 pm Canberra time
           enabled: false
           input:
             mintrashage: 10

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -27,6 +27,16 @@ custom:
     s3Bucket:
       prod: "dea-lambda"
       dev: "dea-lambdas-dev"
+  s3Sync:
+    - bucketName: ${self:custom.CustEnv.s3Bucket.${self:custom.Stage}} # required
+      localDir: /g/data/v10/work/coherence/ # required
+
+resources:
+  Resources:
+    AssetsBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: ${self:custom.CustEnv.s3Bucket.${self:custom.Stage}}
 
 provider:
   name: aws
@@ -37,7 +47,7 @@ provider:
     hostkey: 'orchestrator.raijin.users.default.host'
     userkey: 'orchestrator.raijin.users.default.user'
     pkey: 'orchestrator.raijin.users.default.pkey'
-    DEA_MODULE: dea/20181011
+    DEA_MODULE: dea/20181015
     PROJECT: v10
     QUEUE: normal
   region: ap-southeast-2
@@ -74,6 +84,7 @@ functions:
   execute_sync:
     # trasharchived is set to 'yes' only for the albers products and not for the scenes
     handler: handler.execute_ssh_command
+    description: Execute dea-sync tool to sync datasets from the specified path
     environment:
       cmd: 'execute_sync --dea-module ${self:provider.environment.DEA_MODULE}
                          --queue ${self:provider.environment.QUEUE}
@@ -150,6 +161,7 @@ functions:
             trasharchived: no
   execute_ingest:
     handler: handler.execute_ssh_command
+    description: Execute dea-submit-ingest qsub tool to ingest datasets to the database
     environment:
       cmd: 'execute_ingest --dea-module ${self:provider.environment.DEA_MODULE}
                            --queue ${self:provider.environment.QUEUE}
@@ -196,6 +208,7 @@ functions:
             product: ls7_pq_albers
   execute_fractional_cover:
     handler: handler.execute_ssh_command
+    description: Execute datacube-fc submit tool to generate fc and ingest them to the database
     environment:
       cmd: 'execute_fractional_cover --dea-module ${self:provider.environment.DEA_MODULE}
                                      --queue ${self:provider.environment.QUEUE}
@@ -221,6 +234,7 @@ functions:
             tag: 'ls7_fc2018'
   execute_wofs:
     handler: handler.execute_ssh_command
+    description: Execute datacube-wofs submit tool to generate wofs and ingest them to the database
     environment:
       cmd: 'execute_wofs --dea-module ${self:provider.environment.DEA_MODULE}
                          --queue ${self:provider.environment.QUEUE}
@@ -237,52 +251,33 @@ functions:
             year: 2018
             product: wofs_albers
             tag: '2018'
-  execute_stacker:
-    handler: handler.execute_ssh_command
-    environment:
-      cmd: 'execute_stacker --dea-module ${self:provider.environment.DEA_MODULE}
-                            --queue ${self:provider.environment.QUEUE}
-                            --project ${self:provider.environment.PROJECT}
-                            --year <%= year %>
-                            --app-config <%= appconfig %>'
-    events:
-      - schedule:
-          rate: cron(30 04 * * ? *) # Run daily, at 04:30:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            appconfig: ls8_nbar_albers.yaml
-      - schedule:
-          rate: cron(45 04 * * ? *) # Run daily, at 04:45:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            appconfig: ls8_nbart_albers.yaml
-      - schedule:
-          rate: cron(00 05 * * ? *) # Run daily, at 05:00:00 am UTC time
-          enabled: false
-          input:
-            year: 2018
-            appconfig: ls8_pq_albers.yaml
   execute_coherence:
     # execute_coherence shall not be used on nbar/nbart/pq albers products
     handler: handler.execute_ssh_command
+    description: Execute dea-coherence tool to check the database inconsistencies (duplicates, siblings, locationless)
     environment:
       cmd: 'execute_coherence --dea-module ${self:provider.environment.DEA_MODULE}
                               --queue ${self:provider.environment.QUEUE}
                               --project ${self:provider.environment.PROJECT}
-                              --stage ${self:custom.Stage}
-                              --timerange <%= timerange %>
-                              --product <%= product %>'
+                              --timerange <%= timerange %>'
     events:
       - schedule:
-          rate: cron(10 08 ? * THU *) # Run every Thursday, at 08:10:00 am UTC time
+          rate: cron(20 10 ? * * *) # Run every day, at 08:20 pm Canberra time
           enabled: false
           input:
-            timerange: '2018-01-01 < time < 2018-12-31'
-            product: ls8_fc_albers
+            timerange: 'time in 2018'
+  execute_notify_on_error_ds:
+    handler: handler.execute_ssh_command
+    description: Upload csv file to S3 and send an email, if coherence tool detects bad datasets in the database
+    environment:
+      cmd: 'execute_notify_on_error_ds --dea-module ${self:provider.environment.DEA_MODULE}'
+    events:
+      - schedule:
+          rate: cron(20 10 ? * SUN *) # Run every Sunday, at 08:20 pm Canberra time
+          enabled: false
   execute_clean:
     handler: handler.execute_ssh_command
+    description: Execute dea-clean tool to clean the file on the disk
     environment:
       cmd: 'execute_clean --dea-module ${self:provider.environment.DEA_MODULE}
                           --queue ${self:provider.environment.QUEUE}
@@ -291,7 +286,7 @@ functions:
                           --search-string <%= searchstr %>'
     events:
       - schedule:
-          rate: cron(00 06 * * ? *)  # Run daily, at 06:00:00 am UTC time
+          rate: cron(20 10 ? * SUN *) # Run every Sunday, at 08:20 pm Canberra time
           enabled: false
           input:
             mintrashage: 10

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -249,22 +249,27 @@ functions:
       cmd: 'execute_coherence --dea-module ${self:provider.environment.DEA_MODULE}
                               --queue ${self:provider.environment.QUEUE}
                               --project ${self:provider.environment.PROJECT}
-                              --timerange <%= timerange %>'
+                              --timequery <%= timequery %>'
     events:
       - schedule:
           rate: cron(00 09 ? * * *) # Run every day, at 07:00 pm Canberra time
-          enabled: false
+          enabled: true
           input:
-            timerange: "'\''time in 2018'\''"
+            timequery: "time in 2018"
   execute_notify_on_error_ds:
-    handler: handler.email_notification
-    description: Upload csv file to S3 and send an email, if coherence tool detects bad datasets in the database
+    handler: handler.execute_ssh_command
+    description: Detect CSV file containing discrepencies in database, upload CSV to S3 and notify (Slack and Email)
     environment:
-      cmd: 'execute_notify_on_error_ds --dea-module ${self:provider.environment.DEA_MODULE}'
+      cmd: 'execute_notify_on_error_ds --dea-module ${self:provider.environment.DEA_MODULE}
+                                       --awsprofile <%= awsprofile %>
+                                       --recemail <%= recemail %>'
     events:
       - schedule:
-          rate: cron(00 10 ? * * *) # Run every day, at 08:00 pm Canberra time
-          enabled: false
+          rate: cron(00 12 ? * * *) # Run every day, at 10:00 pm Canberra time
+          enabled: true
+          input:
+            awsprofile: default
+            recemail: nci.monitor@dea.ga.gov.au # Recepient's email address
   execute_clean:
     handler: handler.execute_ssh_command
     description: Execute dea-clean tool to clean the file on the disk

--- a/raijin_scripts/execute_coherence/run
+++ b/raijin_scripts/execute_coherence/run
@@ -13,55 +13,22 @@ while [[ $# -gt 0 ]]; do
         --project )             shift
                                 PROJECT=$1
                                 ;;
-        --stage )               shift
-                                STAGE=$1
-                                ;;
         --timerange )           shift
                                 RANGE_EXP=$1
-                                ;;
-        --product )             shift
-                                PRODUCT=$1
                                 ;;
         * )                     exit 0
     esac
     shift
 done
 
-WORKDIR=/g/data/v10/work/coherence/"${PRODUCT}"/$(date '+%FT%H%M')
-SUBMISSION_LOG="$WORKDIR"/"${PRODUCT}"-coherence-submission-$(date '+%F-%T').log
-count=0
-dbhostname='agdcdev-db.nci.org.au'
-dbport='6432'
-dbname='datacube'
+WORKDIR=/g/data/v10/work/coherence/$(date '+%F')
+SUBMISSION_LOG="$WORKDIR"/Coherence_$(date '+%H_%m_%s').log
 
 mkdir -p "${WORKDIR}"
 echo "Start time: " "$(date '+%F-%T')" > "$SUBMISSION_LOG"
 
 module use /g/data/v10/public/modules/modulefiles
 module load "${MODULE}"
-while read -r LINE; do
-  if [[ "$count" -eq 1 ]]
-  then
-      dbhostname="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
-  elif [[ "$count" -eq 2 ]]
-  then
-      dbport="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
-  elif [[ "$count" -eq 3 ]]
-  then
-      dbname="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
-  fi
-
-  if [[ "${STAGE}" == "dev"  && "$LINE" == "[dea-dev]" ]]; then
-      count=$((count+1))
-  fi
-
-  if [[ "${STAGE}" == "prod"  && "$LINE" == "[datacube]" ]]; then
-      count=$((count+1))
-  fi
-done  < "$DATACUBE_CONFIG_PATH"
 
 cd "${WORKDIR}"
 
@@ -74,21 +41,13 @@ echo ""
 # Check if we can connect to the database
 datacube -vv system check
 
-# Read agdc datasets from the database before dea-coherence process
-echo ""
-echo "***************************************************************************"
-echo "Read previous agdc_dataset product names and count before coherence process"
-echo "Connected to the database host name: $dbhostname"
-echo "Connected to the database port number: $dbport"
-echo "Connected to the database name: $dbname"
-psql -h "${dbhostname}" -p "${dbport}"  -d "${dbname}"  -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
-echo "***************************************************************************"
-
 echo ""
 echo "Starting coherence process......"
 ##################################################################################################
 # Qsub dea-coherence process
 ##################################################################################################
-qsub -V -N dea-coherence -q "${QUEUE}" -W umask=33 -l wd,walltime=20:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" -o "$WORKDIR" -e "$WORKDIR" -- dea-coherence --check-ancestors --check-siblings --archive-siblings --check-locationless --archive-locationless "${RANGE_EXP}" product="${PRODUCT}"
+qsub -V -N dea-coherence -q "${QUEUE}" -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" \
+    -o "$WORKDIR" -e "$WORKDIR" -m abe -M nci.monitor@dea.ga.gov.au \
+    -- dea-coherence --check-siblings --check-locationless --check-downstream-ds "${RANGE_EXP}"
 
 EOF

--- a/raijin_scripts/execute_coherence/run
+++ b/raijin_scripts/execute_coherence/run
@@ -13,7 +13,7 @@ while [[ $# -gt 0 ]]; do
         --project )             shift
                                 PROJECT=$1
                                 ;;
-        --timerange )           shift
+        --timequery )           shift
                                 RANGE_EXP=$1
                                 ;;
         * )                     exit 0
@@ -48,6 +48,6 @@ echo "Starting coherence process......"
 ##################################################################################################
 qsub -V -N dea-coherence -q "${QUEUE}" -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" \
     -o "$WORKDIR" -e "$WORKDIR" -m abe -M nci.monitor@dea.ga.gov.au \
-    -- dea-coherence --check-siblings --check-locationless --check-downstream-ds "${RANGE_EXP}"
+    -- dea-coherence --check-siblings --check-locationless --check-downstream-ds '"${RANGE_EXP}"'
 
 EOF

--- a/raijin_scripts/execute_notify_on_error_ds/run
+++ b/raijin_scripts/execute_notify_on_error_ds/run
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -eu
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case ${key} in
+        --dea-module )          shift
+                                MODULE=$1
+                                ;;
+        * )                     exit 1
+    esac
+    shift
+done
+
+module use /g/data/v10/public/modules/modulefiles
+module load "$MODULE"
+
+# If aws cli is not installed, exit
+aws --version 2> /dev/null || exit 0;
+
+# Get the latest csv file from the coherence directory
+file=$(find /g/data/v10/work/coherence/ -type f -name '*.csv' -print | sort | tail -n -1)
+num_rows=$(head "$file" | wc -l)
+
+# Check if we have any bad datasets in the csv file
+[ "$num_rows" -lt 2 ] && echo "No bad datasets found within the database" && exit 0;
+
+filename=~/.aws/credentials
+
+datetime=$(date '+%F-%T')
+
+# Recepient's email address
+RECP=nci.monitor@dea.ga.gov.au
+
+# -s: Returns true if file exists and has a size > 0
+if [[ -s ~/.aws/credentials ]]; then
+    while read -ra line; 
+    do
+        for word in "${line[@]}";
+        do
+            [ "$word" = "[devProfile]" ] && exists="$word"
+        done;
+    done < "$filename"
+
+    if [ "$exists" ]
+    then
+        aws configure list --profile devProfile
+
+        s3_file=s3://dea-lambdas-dev/coherence/error_datasets_$(date '+%F').csv
+
+        # Upload to aws s3
+        aws --profile devProfile s3 cp "$file" "$s3_file"
+
+        # Email Content
+        email_content="
+         ${datetime} ----------------------------------- Begin -----------------------------------
+         ${datetime} Event: Erroneous_datasets_found_in_database (Reported by coherence tool)
+         ${datetime} ---------------------------- CSV File location ------------------------------
+         ${datetime}
+         ${datetime} NCI: ${file}
+         ${datetime} AWS S3: s3://dea-lambdas-dev/coherence/error_datasets_$(date '+%F').csv
+         ${datetime} 
+         ${datetime} ------------------------------------ End ------------------------------------"
+
+        echo "$email_content" | mailx -s "Erroneous datasets detected ($datetime)" $RECP
+    else
+        echo "'devProfile' does not exist in '~/.aws/credentials' file"
+        exit 0
+    fi
+else
+    echo "'~/.aws/credentials' file not found"
+    exit 0
+fi

--- a/raijin_scripts/execute_notify_on_error_ds/run
+++ b/raijin_scripts/execute_notify_on_error_ds/run
@@ -7,7 +7,13 @@ while [[ $# -gt 0 ]]; do
         --dea-module )          shift
                                 MODULE=$1
                                 ;;
-        * )                     exit 1
+        --awsprofile )          shift
+                                AWS_PROFILE=$1
+                                ;;
+        --recemail )            shift
+                                RECP=$1
+                                ;;
+        * )                     exit 0
     esac
     shift
 done
@@ -29,42 +35,48 @@ filename=~/.aws/credentials
 
 datetime=$(date '+%F-%T')
 
-# Recepient's email address
-RECP=nci.monitor@dea.ga.gov.au
-
 # -s: Returns true if file exists and has a size > 0
 if [[ -s ~/.aws/credentials ]]; then
+    exists=
+    profilename="$AWS_PROFILE"
     while read -ra line; 
     do
         for word in "${line[@]}";
         do
-            [ "$word" = "[devProfile]" ] && exists="$word"
+            [ "$word" = "[$profilename]" ] && exists="$word"
         done;
     done < "$filename"
 
     if [ "$exists" ]
     then
-        aws configure list --profile devProfile
+        aws configure list --profile "$profilename"
 
-        s3_file=s3://dea-lambdas-dev/coherence/error_datasets_$(date '+%F').csv
+        s3_file=s3://dea-lambda/serverless/coherence/error_datasets_$(date '+%F').csv
 
         # Upload to aws s3
-        aws --profile devProfile s3 cp "$file" "$s3_file"
+        aws s3 --profile "$profilename" cp "$file" "$s3_file"
 
         # Email Content
-        email_content="
-         ${datetime} ----------------------------------- Begin -----------------------------------
-         ${datetime} Event: Erroneous_datasets_found_in_database (Reported by coherence tool)
-         ${datetime} ---------------------------- CSV File location ------------------------------
-         ${datetime}
-         ${datetime} NCI: ${file}
-         ${datetime} AWS S3: s3://dea-lambdas-dev/coherence/error_datasets_$(date '+%F').csv
-         ${datetime} 
-         ${datetime} ------------------------------------ End ------------------------------------"
+        email_content="$datetime
 
-        echo "$email_content" | mailx -s "Erroneous datasets detected ($datetime)" $RECP
+         Sub: Erroneous datasets found in database (Reported by coherence tool)
+
+         NCI file path: ${file}
+         AWS S3 url   : s3://dea-lambda/serverless/coherence/error_datasets_$(date '+%F').csv
+
+         "
+
+        # Send Email to the recepient email ID (mailx will not work in Raijin Login nodes)
+        echo "$email_content" | mailx -s "Erroneous datasets detected ($datetime)" "$RECP"
+        MSG="$email_content"
+
+        PAYLOAD="payload={\"text\": \"$MSG\"}"
+        DEA_ORCHESTRATION_WEBHOOK=https://hooks.slack.com/services/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
+
+        # Send slack notification to '#dea-orchestration' channel about new CSV file that has been pushed to s3 bucket
+        curl -X POST --data-urlencode "$PAYLOAD" "$DEA_ORCHESTRATION_WEBHOOK"
     else
-        echo "'devProfile' does not exist in '~/.aws/credentials' file"
+        echo "'$profilename' profile does not exist in '~/.aws/credentials' file"
         exit 0
     fi
 else


### PR DESCRIPTION
## Reason for this pull request
Existing database contains many duplicate datasets, locationless datasets, and downstream datasets with locationless source dataset. We need to periodically check such inconsistencies in the database and log erroneous dataset info into a `CSV` file. Also run a execute_notify script to see if we have any such erroneous datasets in the `CSV` file, then notify user via slack channel to take further action on such datasets.

## Proposed solutions
1) Automate execution of `dea-coherence` tool to check `locationless`, `sibling`, and `erroneous downstream` datasets. And if we have any mismatches, log the same into a `CSV` file.
2) Automate notify script (scheduled daily) to check for any new `CSV` file and if any, then upload the `CSV` file to `S3` bucket and notify via slack channel (`#dea-orchestration` channel).
