### PR TITLE
Fix indentation for s2ard execution

### DIFF
--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -302,48 +302,48 @@ functions:
                           --days-to-process <%= days_to_process %>
                           --task <%= task %>
                           --obs-year <%= obs_year %>'
-      events:
-        - schedule:
-            rate: cron(17 05 ? * FRI *) # Run every Friday at 3:05 AM, AEST
-            enabled: false
-            input:
-              task: level1
-              start_date_offset: 7
-              days_to_process: 7
-              output_dir: /g/data/v10/AGDCv2/datacube-ingestion/indexed-products/cophub/s2/s2_l1c_yamls
-              copy_parent_dir_count: 1
-              level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
-              year: current
-        - schedule:
-            rate: cron(17 10 28 * ? *) # Run on the 28th of every month at 3:10 AM, AEST
-            enabled: false
-            input:
-              task: level1
-              start_date_offset: 7
-              days_to_process: 31
-              output_dir: /g/data/v10/AGDCv2/datacube-ingestion/indexed-products/cophub/s2/s2_l1c_yamls
-              copy_parent_dir_count: 1
-              level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
-              obs_year: previous
-        - schedule:
-            rate: cron(17 05 ? * FRI *) # Run every Friday at 3:05 AM, AEST
-            enabled: false
-            input:
-              task: level2
-              start_date_offset: 28
-              days_to_process: 7
-              output_dir: /g/data/if87/datacube/002/S2_MSI_ARD/packaged
-              copy_parent_dir_count: 0 # IGNORED FOR L2
-              level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
-              obs_year: current
-        - schedule:
-            rate: cron(17 10 28 * ? *) # Run on the 28th of every month at 3:10 AM, AEST
-            enabled: false
-            input:
-              task: level2
-              start_date_offset: 28
-              days_to_process: 31
-              output_dir: /g/data/if87/datacube/002/S2_MSI_ARD/packaged
-              copy_parent_dir_count: 0 # IGNORED FOR L2
-              level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
-              obs_year: previous
+    events:
+      - schedule:
+          rate: cron(17 05 ? * FRI *) # Run every Friday at 3:05 AM, AEST
+          enabled: false
+          input:
+            task: level1
+            start_date_offset: 7
+            days_to_process: 7
+            output_dir: /g/data/v10/AGDCv2/datacube-ingestion/indexed-products/cophub/s2/s2_l1c_yamls
+            copy_parent_dir_count: 1
+            level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
+            year: current
+      - schedule:
+          rate: cron(17 10 28 * ? *) # Run on the 28th of every month at 3:10 AM, AEST
+          enabled: false
+          input:
+            task: level1
+            start_date_offset: 7
+            days_to_process: 31
+            output_dir: /g/data/v10/AGDCv2/datacube-ingestion/indexed-products/cophub/s2/s2_l1c_yamls
+            copy_parent_dir_count: 1
+            level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
+            obs_year: previous
+      - schedule:
+          rate: cron(17 05 ? * FRI *) # Run every Friday at 3:05 AM, AEST
+          enabled: false
+          input:
+            task: level2
+            start_date_offset: 28
+            days_to_process: 7
+            output_dir: /g/data/if87/datacube/002/S2_MSI_ARD/packaged
+            copy_parent_dir_count: 0 # IGNORED FOR L2
+            level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
+            obs_year: current
+      - schedule:
+          rate: cron(17 10 28 * ? *) # Run on the 28th of every month at 3:10 AM, AEST
+          enabled: false
+          input:
+            task: level2
+            start_date_offset: 28
+            days_to_process: 31
+            output_dir: /g/data/if87/datacube/002/S2_MSI_ARD/packaged
+            copy_parent_dir_count: 0 # IGNORED FOR L2
+            level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
+            obs_year: previous


### PR DESCRIPTION
* Indentation issue caused the events to be nested under the environment (which is wrong).
* Broke deployment because it created environment variables that weren't strings (due to nesting).