### PR TITLE
typo fix in raijin-run; fix dates in serverless.yml

### DIFF
--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -308,18 +308,18 @@ functions:
           enabled: false
           input:
             task: level1
-            start_date_offset: 7
+            start_date_offset: 8 # TODAY - 1 day buffer - 7 days to process
             days_to_process: 7
             output_dir: /g/data/v10/AGDCv2/datacube-ingestion/indexed-products/cophub/s2/s2_l1c_yamls
             copy_parent_dir_count: 1
             level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
-            year: current
+            obs_year: current
       - schedule:
           rate: cron(17 10 28 * ? *) # Run on the 28th of every month at 3:10 AM, AEST
           enabled: false
           input:
             task: level1
-            start_date_offset: 7
+            start_date_offset: 32 # TODAY - 1 day buffer - 31 days to process
             days_to_process: 31
             output_dir: /g/data/v10/AGDCv2/datacube-ingestion/indexed-products/cophub/s2/s2_l1c_yamls
             copy_parent_dir_count: 1
@@ -330,7 +330,7 @@ functions:
           enabled: false
           input:
             task: level2
-            start_date_offset: 28
+            start_date_offset: 35 # TODAY - 28 day buffer - 7 days to process
             days_to_process: 7
             output_dir: /g/data/if87/datacube/002/S2_MSI_ARD/packaged
             copy_parent_dir_count: 0 # IGNORED FOR L2
@@ -341,7 +341,7 @@ functions:
           enabled: false
           input:
             task: level2
-            start_date_offset: 28
+            start_date_offset: 59 # TODAY - 28 day buffer - 31 days to process
             days_to_process: 31
             output_dir: /g/data/if87/datacube/002/S2_MSI_ARD/packaged
             copy_parent_dir_count: 0 # IGNORED FOR L2

--- a/raijin_scripts/execute_s2ard/run
+++ b/raijin_scripts/execute_s2ard/run
@@ -97,7 +97,6 @@ for _year in "${OBS_YEAR[@]}"; do
                         --output-dir "$OUTPUT_DIR" \
                         --start-date "$FILE_MOD_START" \
                         --end-date "$FILE_MOD_END" \
-                        --dry-run
                     ;;
         "level2"    )
                     cd "$RUNDIR/level2"


### PR DESCRIPTION
* Fixing 2 typos in the configuration files (--dry-run and --year)
* Fixing dates to be a cumulative offset (as per execution code)