### PR TITLE
Cleanup duplicate/locationless parent/archived parent with derived children

### DIFF
--- a/lambda_functions/execute_ssh_command_js/handler.js
+++ b/lambda_functions/execute_ssh_command_js/handler.js
@@ -77,7 +77,7 @@ exports.execute_ssh_command = (event, context, callback) => {
                                    console.log(`STDERR: ${stderr}`);
                                    console.log(`SSH returncode: ${code}`);
                                    //  Return error with error information back to the caller
-                                   callback(`Failed to execute SSH command, ${stderr}`);
+                                   callback(`Failed to execute, ${command}, command`);
                         }
                      }
                    })

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -40,7 +40,7 @@ provider:
     webhook: 'orchestrator.raijin.users.default.slack.webhookurl'
     DEA_MODULE: dea/20181015
     PROJECT: v10
-    QUEUE: express
+    QUEUE: normal
   region: ap-southeast-2
   deploymentBucket: ${self:custom.CustEnv.s3Bucket.${self:custom.Stage}}
   stackTags:
@@ -75,7 +75,7 @@ functions:
   execute_sync:
     # trasharchived is set to 'yes' only for the albers products and not for the scenes
     handler: handler.execute_ssh_command
-    description: Execute dea-sync tool to sync datasets from the specified path
+    description: Sync landsat 7/8 scenes
     environment:
       cmd: 'execute_sync --dea-module ${self:provider.environment.DEA_MODULE}
                          --queue ${self:provider.environment.QUEUE}
@@ -243,20 +243,22 @@ functions:
             product: wofs_albers
             tag: '2018'
   execute_coherence:
-    # execute_coherence shall not be used on nbar/nbart/pq albers products
+    # Note: Keep `--timequery` argument as the last argument in the environment.cmd
     handler: handler.execute_ssh_command
-    description: Execute dea-coherence tool to check the database inconsistencies (duplicates, siblings, locationless)
+    description: Execute dea-coherence tool to report archived/locationless parent and their derived datasets
     environment:
       cmd: 'execute_coherence --dea-module ${self:provider.environment.DEA_MODULE}
                               --queue ${self:provider.environment.QUEUE}
                               --project ${self:provider.environment.PROJECT}
-                              --timequery "<%= timequery %>"'
+                              --product <%= product %>
+                              --timequery <%= timequery %>'
     events:
       - schedule:
-          rate: cron(37 04 ? * * *) # Run every day, at 07:00 pm Canberra time
+          rate: cron(00 09 ? * TUE *) # Run every Tuesday, at 07:00 pm Canberra time
           enabled: true
           input:
-            timequery: "2017 < time < 2018"
+            timequery: 'time in 2018'
+            product: all
   execute_notify_on_error_ds:
     handler: handler.execute_ssh_command
     description: Detect CSV file containing discrepencies in database, upload CSV to S3 and notify (Slack and Email)
@@ -275,21 +277,24 @@ functions:
             awsprofile: default
             recemail: nci.monitor@dea.ga.gov.au # Recepient's email address
   execute_clean:
+    # Note: Keep `--search-paths` argument as the last argument in the environment.cmd
     handler: handler.execute_ssh_command
-    description: Execute dea-clean tool to clean the file on the disk
+    description: Execute dea-clean tool to trash files on disk whose index were archived at least 3 days ago
     environment:
       cmd: 'execute_clean --dea-module ${self:provider.environment.DEA_MODULE}
                           --queue ${self:provider.environment.QUEUE}
                           --project ${self:provider.environment.PROJECT}
-                          --min-trash-age-hours <%= mintrashage %>
-                          --search-string <%= searchstr %>'
+                          --min-trash-age <%= min_trash_age %>
+                          --search-paths <%= search_paths %>'
     events:
       - schedule:
-          rate: cron(00 11 ? * SUN *) # Run every Sunday, at 09:00 pm Canberra time
-          enabled: false
+          rate: cron(00 13 ? * TUE *) # Run every Tuesday, at 11:00 pm Canberra time
+          enabled: true
           input:
-            mintrashage: 10
-            searchstr: ls8_nbar_albers
+            min_trash_age: 72 # 72 hours
+            search_paths: /g/data/rs0/datacube/002/
+                          /g/data/fk4/datacube/002/FC/
+                          /g/data/fk4/datacube/002/WOfS/WOfS_25_2_1/netcdf/
   execute_s2ard:
     handler: handler.execute_ssh_command
     environment:
@@ -347,4 +352,3 @@ functions:
             copy_parent_dir_count: 0 # IGNORED FOR L2
             level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
             obs_year: previous
-

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -40,7 +40,7 @@ provider:
     webhook: 'orchestrator.raijin.users.default.slack.webhookurl'
     DEA_MODULE: dea/20181015
     PROJECT: v10
-    QUEUE: normal
+    QUEUE: express
   region: ap-southeast-2
   deploymentBucket: ${self:custom.CustEnv.s3Bucket.${self:custom.Stage}}
   stackTags:
@@ -253,10 +253,10 @@ functions:
                               --timequery "<%= timequery %>"'
     events:
       - schedule:
-          rate: cron(00 09 ? * * *) # Run every day, at 07:00 pm Canberra time
+          rate: cron(37 04 ? * * *) # Run every day, at 07:00 pm Canberra time
           enabled: true
           input:
-            timequery: 'time in 2018'
+            timequery: "2017 < time < 2018"
   execute_notify_on_error_ds:
     handler: handler.execute_ssh_command
     description: Detect CSV file containing discrepencies in database, upload CSV to S3 and notify (Slack and Email)
@@ -304,7 +304,7 @@ functions:
                           --obs-year <%= obs_year %>'
     events:
       - schedule:
-          rate: cron(17 05 ? * FRI *) # Run every Friday at 3:05 AM, AEST
+          rate: cron(05 17 ? * FRI *) # Run every Friday at 3:05 AM, AEST
           enabled: false
           input:
             task: level1
@@ -315,7 +315,7 @@ functions:
             level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
             obs_year: current
       - schedule:
-          rate: cron(17 10 28 * ? *) # Run on the 28th of every month at 3:10 AM, AEST
+          rate: cron(10 17 28 * ? *) # Run on the 28th of every month at 3:10 AM, AEST
           enabled: false
           input:
             task: level1
@@ -326,7 +326,7 @@ functions:
             level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
             obs_year: previous
       - schedule:
-          rate: cron(17 05 ? * FRI *) # Run every Friday at 3:05 AM, AEST
+          rate: cron(05 17 ? * FRI *) # Run every Friday at 3:05 AM, AEST
           enabled: false
           input:
             task: level2
@@ -337,7 +337,7 @@ functions:
             level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
             obs_year: current
       - schedule:
-          rate: cron(17 10 28 * ? *) # Run on the 28th of every month at 3:10 AM, AEST
+          rate: cron(10 17 28 * ? *) # Run on the 28th of every month at 3:10 AM, AEST
           enabled: false
           input:
             task: level2
@@ -347,3 +347,4 @@ functions:
             copy_parent_dir_count: 0 # IGNORED FOR L2
             level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
             obs_year: previous
+

--- a/raijin_scripts/execute_clean/run
+++ b/raijin_scripts/execute_clean/run
@@ -1,41 +1,65 @@
 #!/bin/bash
-
 set -eu
 
-
-while [[ $# -gt 0 ]]; do
+while [[ "$#" -gt 0 ]]; do
     key="$1"
-    case ${key} in
-        --min-trash-age-hours ) shift
-                                MIN_TRASH_AGE=$1
-                                ;;
-        --search-string )       shift
-                                SEARCH_STRING=$1
-                                ;;
+    case "${key}" in
         --dea-module )          shift
-                                DEA_MODULE=$1
+                                MODULE="$1"
                                 ;;
         --queue )               shift
-                                QUEUE=$1
+                                QUEUE="$1"
                                 ;;
         --project )             shift
-                                PROJECT=$1
+                                PROJECT="$1"
                                 ;;
-        * )                     exit 1
+        --min-trash-age )       shift
+                                TRASH_AGE="$1"
+                                ;;
+        --search-paths )        shift
+                                SEARCH_PATHS="$*"
+                                break # Last input argument and hence exiting while loop
+                                ;;
+        * )
+          echo "Input key, '$key', did not match the expected input argument key"
+          exit 1
+          ;;
     esac
     shift
 done
 
+WORKDIR=/g/data/v10/work/archive/clean/$(date '+%Y-%m')
+SUBMISSION_LOG="$WORKDIR"/dea-clean_$(date '+%F_%T').log
 
-echo Loading module "${DEA_MODULE}"
-echo Submitting PBS job to run dea-clean indexed --min-trash-age-hours "${MIN_TRASH_AGE}" "${SEARCH_STRING}"
+mkdir -p "${WORKDIR}"
+echo "Start time: " "$(date '+%F-%T')" > "$SUBMISSION_LOG"
 
 module use /g/data/v10/public/modules/modulefiles
-module use /g/data/v10/private/modules/modulefiles
+module load "${MODULE}"
 
-module load "${DEA_MODULE}"
+MIN_TRASH_AGE="--min-trash-age-hours ${TRASH_AGE}"
 
-mkdir -p /g/data/v10/work/clean_pbs_logs/
-cd /g/data/v10/work/clean_pbs_logs/
+cd "${WORKDIR}"
 
-qsub -V -N dea-clean -q "${QUEUE}" -W umask=33 -l wd,walltime=5:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" -- dea-clean indexed --min-trash-age-hours "${MIN_TRASH_AGE}" "${SEARCH_STRING}"
+echo Submitting PBS job to run dea-clean archived "${MIN_TRASH_AGE}" "${SEARCH_PATHS}"
+
+nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 << EOF &
+echo "Logging into: ${SUBMISSION_LOG}"
+echo ""
+echo Loading module ${MODULE}
+echo ""
+
+# Check if we can connect to the database
+datacube -vv system check
+
+echo ""
+echo "Starting dea-clean process......"
+
+##################################################################################################
+# Qsub dea-clean process
+##################################################################################################
+qsub -V -N dea-clean -q ${QUEUE} -W umask=33 -l wd,walltime=20:00:00,mem=25GB,ncpus=1 -P ${PROJECT} \
+-o ${WORKDIR} -e ${WORKDIR} -m abe -M nci.monitor@dea.ga.gov.au \
+-- dea-clean archived --dry-run ${MIN_TRASH_AGE} ${SEARCH_PATHS}
+
+EOF

--- a/raijin_scripts/execute_coherence/run
+++ b/raijin_scripts/execute_coherence/run
@@ -13,6 +13,9 @@ while [[ $# -gt 0 ]]; do
         --project )             shift
                                 PROJECT=$1
                                 ;;
+        --product )             shift
+                                PRODUCT=$1
+                                ;;
         --timequery )           shift
                                 RANGE_EXP=$1
                                 ;;
@@ -30,12 +33,17 @@ echo "Start time: " "$(date '+%F-%T')" > "$SUBMISSION_LOG"
 module use /g/data/v10/public/modules/modulefiles
 module load "${MODULE}"
 
+PRODUCT_QUERY=''
+if [ "$PRODUCT" ]; then
+   PRODUCT_QUERY="product=$PRODUCT"
+fi
+
 cd "${WORKDIR}"
 
 nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 << EOF &
 echo "Logging into: ${SUBMISSION_LOG}"
 echo ""
-echo Loading module "${MODULE}"
+echo Loading module ${MODULE}
 echo ""
 
 # Check if we can connect to the database
@@ -46,8 +54,8 @@ echo "Starting coherence process......"
 ##################################################################################################
 # Qsub dea-coherence process
 ##################################################################################################
-qsub -V -N dea-coherence -q "${QUEUE}" -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -P "${PROJECT}" \
-    -o "$WORKDIR" -e "$WORKDIR" -m abe -M nci.monitor@dea.ga.gov.au \
-    -- dea-coherence --check-siblings --check-locationless --check-downstream-ds '"${RANGE_EXP}"'
+qsub -V -N dea-coherence -q ${QUEUE} -W umask=33 -l wd,walltime=20:00:00,mem=25GB,ncpus=1 -P ${PROJECT} \
+    -o ${WORKDIR} -e ${WORKDIR} -m abe -M nci.monitor@dea.ga.gov.au \
+    -- dea-coherence --check-downstream --check-locationless --check-ancestors ${PRODUCT_QUERY} '${RANGE_EXP}'
 
 EOF

--- a/raijin_scripts/execute_coherence/run
+++ b/raijin_scripts/execute_coherence/run
@@ -1,25 +1,29 @@
 #!/bin/bash
 set -eu
 
-while [[ $# -gt 0 ]]; do
+while [[ "$#" -gt 0 ]]; do
     key="$1"
-    case ${key} in
+    case "${key}" in
         --dea-module )          shift
-                                MODULE=$1
+                                MODULE="$1"
                                 ;;
         --queue )               shift
-                                QUEUE=$1
+                                QUEUE="$1"
                                 ;;
         --project )             shift
-                                PROJECT=$1
+                                PROJECT="$1"
                                 ;;
         --product )             shift
-                                PRODUCT=$1
+                                PRODUCT="$1"
                                 ;;
         --timequery )           shift
-                                RANGE_EXP=$1
+                                RANGE_EXP="'$*'"
+                                break # Last input argument and hence exiting while loop
                                 ;;
-        * )                     exit 1
+        * )
+          echo "Input key, '$key', did not match the expected input argument key"
+          exit 1
+          ;;
     esac
     shift
 done
@@ -33,9 +37,10 @@ echo "Start time: " "$(date '+%F-%T')" > "$SUBMISSION_LOG"
 module use /g/data/v10/public/modules/modulefiles
 module load "${MODULE}"
 
-PRODUCT_QUERY=''
-if [ "$PRODUCT" ]; then
-   PRODUCT_QUERY="product=$PRODUCT"
+if [[ "$PRODUCT" =~ ^(All|all)$ ]]; then
+    PRODUCT_QUERY=''
+else
+    PRODUCT_QUERY="product=$PRODUCT"
 fi
 
 cd "${WORKDIR}"
@@ -51,11 +56,12 @@ datacube -vv system check
 
 echo ""
 echo "Starting coherence process......"
+
 ##################################################################################################
 # Qsub dea-coherence process
 ##################################################################################################
 qsub -V -N dea-coherence -q ${QUEUE} -W umask=33 -l wd,walltime=20:00:00,mem=25GB,ncpus=1 -P ${PROJECT} \
-    -o ${WORKDIR} -e ${WORKDIR} -m abe -M nci.monitor@dea.ga.gov.au \
-    -- dea-coherence --check-downstream --check-locationless --check-ancestors ${PRODUCT_QUERY} '${RANGE_EXP}'
+-o ${WORKDIR} -e ${WORKDIR} -m abe -M nci.monitor@dea.ga.gov.au \
+-- dea-coherence --check-downstream --check-locationless --check-ancestors ${PRODUCT_QUERY} ${RANGE_EXP}
 
 EOF

--- a/raijin_scripts/execute_fractional_cover/run
+++ b/raijin_scripts/execute_fractional_cover/run
@@ -1,31 +1,34 @@
 #!/bin/bash
 set -eu
 
-while [[ $# -gt 0 ]]; do
+while [[ "$#" -gt 0 ]]; do
     key="$1"
-    case ${key} in
+    case "${key}" in
         --year )                shift
-                                YEAR=$1
+                                YEAR="$1"
                                 ;;
         --product )             shift
-                                PRODUCT=$1
+                                PRODUCT="$1"
                                 ;;
         --tag )                 shift
-                                TAG=$1
+                                TAG="$1"
                                 ;;
         --dea-module )          shift
-                                MODULE=$1
+                                MODULE="$1"
                                 ;;
         --queue )               shift
-                                QUEUE=$1
+                                QUEUE="$1"
                                 ;;
         --project )             shift
-                                PROJECT=$1
+                                PROJECT="$1"
                                 ;;
         --stage )               shift
-                                STAGE=$1
+                                STAGE="$1"
                                 ;;
-        * )                     exit 1
+        * )
+          echo "Input key, '$key', did not match the expected input argument key"
+          exit 1
+          ;;
     esac
     shift
 done
@@ -52,28 +55,28 @@ while read -r LINE; do
   if [[ "$count" -eq 1 ]]
   then
       dbhostname="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   elif [[ "$count" -eq 2 ]]
   then
       dbport="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   elif [[ "$count" -eq 3 ]]
   then
       dbname="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   fi
 
   if [[ "${STAGE}" == "dev"  && "$LINE" == "[dea-dev]" ]]; then
-      count=$((count+1))
+      count="$((count+1))"
   fi
 
   if [[ "${STAGE}" == "prod"  && "$LINE" == "[datacube]" ]]; then
-      count=$((count+1))
+      count="$((count+1))"
   fi
 done < "$DATACUBE_CONFIG_PATH"
 
 cd "$OUTPUT_DIR" || exit 1
-APP_CONFIG=$(datacube-fc list | grep "${PRODUCT}")
+APP_CONFIG="$(datacube-fc list | grep "${PRODUCT}")"
 
 # Launch the submission in the background, outputting results to a log file
 nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 <<EOF &

--- a/raijin_scripts/execute_fractional_cover/run
+++ b/raijin_scripts/execute_fractional_cover/run
@@ -79,7 +79,7 @@ APP_CONFIG=$(datacube-fc list | grep "${PRODUCT}")
 nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 <<EOF &
 echo "Logging job: ${JOB_NAME} into: ${SUBMISSION_LOG}"
 echo ""
-echo Loading module "${MODULE}"
+echo Loading module ${MODULE}
 echo ""
 
 # Check if we can connect to the database
@@ -89,10 +89,11 @@ datacube -vv system check
 echo ""
 echo "**********************************************************************"
 echo "Read previous agdc_dataset product names and count before fractional cover process"
-echo "Connected to the database host name: $dbhostname"
-echo "Connected to the database port number: $dbport"
-echo "Connected to the database name: $dbname"
-# psql -h "${dbhostname}" -p "${dbport}" -d "${dbname}" -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
+echo "Connected to the database host name: ${dbhostname}"
+echo "Connected to the database port number: ${dbport}"
+echo "Connected to the database name: ${dbname}"
+psql -h ${dbhostname} -p ${dbport} -d ${dbname} \
+  -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
 echo "**********************************************************************"
 
 echo ""
@@ -100,5 +101,5 @@ echo "Executing fractional cover for ${YEAR} ${PRODUCT} with tag ${TAG}"
 ##################################################################################################
 # Run datacube-fc submit two stage PBS job
 ##################################################################################################
-datacube-fc submit -v -v --project "${PROJECT}" --queue "${QUEUE}" --year "${YEAR}" --app-config "${APP_CONFIG}" --tag "${TAG}"
+datacube-fc submit -v -v --project ${PROJECT} --queue ${QUEUE} --year ${YEAR} --app-config ${APP_CONFIG} --tag ${TAG}
 EOF

--- a/raijin_scripts/execute_ingest/run
+++ b/raijin_scripts/execute_ingest/run
@@ -1,28 +1,31 @@
 #!/bin/bash
 set -eu
 
-while [[ $# -gt 0 ]]; do
+while [[ "$#" -gt 0 ]]; do
     key="$1"
-    case ${key} in
+    case "${key}" in
         --year )                shift
-                                YEAR=$1
+                                YEAR="$1"
                                 ;;
         --product )             shift
-                                PRODUCT=$1
+                                PRODUCT="$1"
                                 ;;
         --dea-module )          shift
-                                MODULE=$1
+                                MODULE="$1"
                                 ;;
         --queue )               shift
-                                QUEUE=$1
+                                QUEUE="$1"
                                 ;;
         --stage )               shift
-                                STAGE=$1
+                                STAGE="$1"
                                 ;;
         --project )             shift
-                                PROJECT=$1
+                                PROJECT="$1"
                                 ;;
-        * )                     exit 1
+        * )
+          echo "Input key, '$key', did not match the expected input argument key"
+          exit 1
+          ;;
     esac
     shift
 done
@@ -49,23 +52,23 @@ while read -r LINE; do
   if [[ "$count" -eq 1 ]]
   then
       dbhostname="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   elif [[ "$count" -eq 2 ]]
   then
       dbport="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   elif [[ "$count" -eq 3 ]]
   then
       dbname="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   fi
 
   if [[ "${STAGE}" == "dev"  && "$LINE" == "[dea-dev]" ]]; then
-      count=$((count+1))
+      count="$((count+1))"
   fi
 
   if [[ "${STAGE}" == "prod"  && "$LINE" == "[datacube]" ]]; then
-      count=$((count+1))
+      count="$((count+1))"
   fi
 done  < "$DATACUBE_CONFIG_PATH"
 

--- a/raijin_scripts/execute_ingest/run
+++ b/raijin_scripts/execute_ingest/run
@@ -27,6 +27,11 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
+# Override echo command to prepend timestamp before echo message
+echo() {
+    command echo "$(date '+%F_%T.%N')" "$@"
+}
+
 WORKDIR=/g/data/v10/work/ingest/"${PRODUCT}"/$(date '+%FT%H%M')
 SUBMISSION_LOG="${WORKDIR}"/ingest-submission-${PRODUCT}-$(date '+%F-%T').log
 JOB_NAME="${YEAR}_${PRODUCT}"
@@ -70,7 +75,7 @@ cd "${WORKDIR}"
 nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 <<EOF &
 echo "Logging job: ${JOB_NAME} into: ${SUBMISSION_LOG}"
 echo ""
-echo Loading module "${MODULE}"
+echo Loading module ${MODULE}
 echo ""
 
 # Check if we can connect to the database
@@ -80,10 +85,11 @@ datacube -vv system check
 echo ""
 echo "**********************************************************************"
 echo "Read previous agdc_dataset product names and count before ingest process"
-echo "Connected to the database host name: $dbhostname"
-echo "Connected to the database port number: $dbport"
-echo "Connected to the database name: $dbname"
-# psql -h "${dbhostname}" -p "${dbport}"  -d "${dbname}"  -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
+echo "Connected to the database host name: ${dbhostname}"
+echo "Connected to the database port number: ${dbport}"
+echo "Connected to the database name: ${dbname}"
+psql -h ${dbhostname} -p ${dbport} -d ${dbname} \
+  -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
 echo "**********************************************************************"
 
 echo ""
@@ -91,5 +97,6 @@ echo "Executing ingest for ${YEAR} ${PRODUCT}"
 ##################################################################################################
 # Run dea-submit-ingest process
 ##################################################################################################
-yes Y | dea-submit-ingest qsub --project "${PROJECT}" --queue "${QUEUE}" -n 5 -t 10 --allow-product-changes --name "${JOB_NAME}" "${PRODUCT}" "${YEAR}"
+yes Y | dea-submit-ingest qsub --project "${PROJECT}" --queue "${QUEUE}" -n 5 -t 10 --allow-product-changes \
+  --name "${JOB_NAME}" "${PRODUCT}" "${YEAR}"
 EOF

--- a/raijin_scripts/execute_notify_on_error_ds/run
+++ b/raijin_scripts/execute_notify_on_error_ds/run
@@ -1,22 +1,26 @@
 #!/bin/bash
 set -eu
 
-while [[ $# -gt 0 ]]; do
+while [[ "$#" -gt 0 ]]; do
     key="$1"
-    case ${key} in
+    case "${key}" in
         --dea-module )          shift
-                                MODULE=$1
+                                MODULE="$1"
                                 ;;
         --webhook )             shift
-                                DEA_ORCHESTRATION_WEBHOOK=$1
+                                DEA_ORCHESTRATION_WEBHOOK="$1"
                                 ;;
         --awsprofile )          shift
-                                AWS_PROFILE=$1
+                                AWS_PROFILE="$1"
                                 ;;
         --recemail )            shift
-                                RECP=$1
+                                RECP="$1"
                                 ;;
-        * )                     exit 1
+        * )
+          echo "Input key, '$key', did not match the expected input argument key"
+          exit 1
+          ;;
+
     esac
     shift
 done
@@ -28,15 +32,15 @@ module load "$MODULE"
 aws --version 2> /dev/null || exit 1;
 
 # Get the latest csv file from the coherence directory
-file=$(find /g/data/v10/work/coherence/ -type f -name '*.csv' -print | sort | tail -n -1)
-num_rows=$(head "$file" | wc -l)
+file="$(find /g/data/v10/work/coherence/ -type f -name '*.csv' -print | sort | tail -n -1)"
+num_rows="$(head "$file" | wc -l)"
 
 # Check if we have any bad datasets in the csv file
 [ "$num_rows" -lt 2 ] && echo "No bad datasets found within the database" && exit 0;
 
 filename=~/.aws/credentials
 
-datetime=$(date '+%F-%T')
+datetime="$(date '+%F-%T')"
 
 # -s: Returns true if file exists and has a size > 0
 if [[ -s ~/.aws/credentials ]]; then

--- a/raijin_scripts/execute_sync/run
+++ b/raijin_scripts/execute_sync/run
@@ -1,37 +1,40 @@
 #!/bin/bash
 set -eu
 
-while [[ $# -gt 0 ]]; do
+while [[ "$#" -gt 0 ]]; do
     key="$1"
-    case ${key} in
+    case "${key}" in
         --dea-module )          shift
-                                MODULE=$1
+                                MODULE="$1"
                                 ;;
         --year )                shift
-                                YEAR=$1
+                                YEAR="$1"
                                 ;;
         --queue )               shift
-                                QUEUE=$1
+                                QUEUE="$1"
                                 ;;
         --project )             shift
-                                PROJECT=$1
+                                PROJECT="$1"
                                 ;;
         --stage )               shift
-                                STAGE=$1
+                                STAGE="$1"
                                 ;;
         --path )                shift
                                 # Expand a shell glob pattern, for more flexible path definition
                                 # See https://stackoverflow.com/a/45933949/119603 for more info
                                 # shellcheck disable=SC2206
-                                PATHS_TO_PROCESS=($1)
+                                PATHS_TO_PROCESS=("$1")
                                 ;;
         --product )             shift
-                                PRODUCT=$1
+                                PRODUCT="$1"
                                 ;;
         --trasharchived )       shift
-                                TRASH_ARC=$1
+                                TRASH_ARC="$1"
                                 ;;
-        * )                     exit 1
+        * )
+          echo "Input key, '$key', did not match the expected input argument key"
+          exit 1
+          ;;
     esac
     shift
 done
@@ -59,23 +62,23 @@ while read -r LINE; do
   if [[ "$count" -eq 1 ]]
   then
       dbhostname="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   elif [[ "$count" -eq 2 ]]
   then
       dbport="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   elif [[ "$count" -eq 3 ]]
   then
       dbname="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   fi
 
   if [[ "${STAGE}" == "dev"  && "$LINE" == "[dea-dev]" ]]; then
-      count=$((count+1))
+      count="$((count+1))"
   fi
 
   if [[ "${STAGE}" == "prod"  && "$LINE" == "[datacube]" ]]; then
-      count=$((count+1))
+      count="$((count+1))"
   fi
 done  < "$DATACUBE_CONFIG_PATH"
 

--- a/raijin_scripts/execute_sync/run
+++ b/raijin_scripts/execute_sync/run
@@ -36,6 +36,11 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
+# Override echo command to prepend timestamp before echo message
+echo() {
+    command echo "$(date '+%F_%T.%N')" "$@"
+}
+
 WORKDIR=/g/data/v10/work/sync/"${PRODUCT}"/$(date '+%FT%H%M')
 SYNC_CACHE="${WORKDIR}"/cache/
 SUBMISSION_LOG="$WORKDIR"/sync-submission-"${PRODUCT}"-$(date '+%F-%T').log
@@ -94,10 +99,11 @@ datacube -vv system check
 echo ""
 echo "**********************************************************************"
 echo "Read previous agdc_dataset product names and count before sync process"
-echo "Connected to the database host name: $dbhostname"
-echo "Connected to the database port number: $dbport"
-echo "Connected to the database name: $dbname"
-# psql -h "${dbhostname}" -p "${dbport}"  -d "${dbname}"  -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
+echo "Connected to the database host name: ${dbhostname}"
+echo "Connected to the database port number: ${dbport}"
+echo "Connected to the database name: ${dbname}"
+psql -h ${dbhostname} -p ${dbport} -d ${dbname} \
+  -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
 echo "**********************************************************************"
 
 echo ""
@@ -105,5 +111,8 @@ echo "Starting Sync process......"
 ##################################################################################################
 # Run dea-sync process
 ##################################################################################################
-qsub -V -N dea-sync -q "${QUEUE}" -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -m ae -M nci.monitor@dea.ga.gov.au -P "${PROJECT}" -o "$WORKDIR" -e "$WORKDIR" -- dea-sync -vvv --cache-folder "$WORKDIR"/cache -j 4 --log-queries "$TRASH_ARCHIVED" --update-locations --index-missing ${PATHS_TO_PROCESS[@]}
+qsub -V -N dea-sync -q ${QUEUE} -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -m ae \
+   -M nci.monitor@dea.ga.gov.au -P "${PROJECT}" -o ${WORKDIR} -e ${WORKDIR} \
+   -- dea-sync -vvv --cache-folder ${WORKDIR}/cache -j 4 --log-queries ${TRASH_ARCHIVED} --update-locations \
+   --index-missing ${PATHS_TO_PROCESS[@]}
 EOF

--- a/raijin_scripts/execute_wofs/run
+++ b/raijin_scripts/execute_wofs/run
@@ -89,10 +89,11 @@ datacube -vv system check
 echo ""
 echo "**********************************************************************"
 echo "Read previous agdc_dataset product names and count before wofs process"
-echo "Connected to the database host name: $dbhostname"
-echo "Connected to the database port number: $dbport"
-echo "Connected to the database name: $dbname"
-# psql -h "${dbhostname}" -p "${dbport}" -d "${dbname}" -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
+echo "Connected to the database host name: ${dbhostname}"
+echo "Connected to the database port number: ${dbport}"
+echo "Connected to the database name: ${dbname}"
+psql -h ${dbhostname} -p ${dbport} -d ${dbname} \
+  -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
 echo "**********************************************************************"
 
 echo ""
@@ -100,5 +101,6 @@ echo "Executing wofs for ${YEAR} ${PRODUCT} with tag ${TAG}"
 ##################################################################################################
 # Run datacube-wofs submit two stage PBS job
 ##################################################################################################
-datacube-wofs submit -v -v --project "${PROJECT}" --queue "${QUEUE}" --year "${YEAR}" --app-config "${APP_CONFIG}" --tag "${TAG}"
+datacube-wofs submit -v -v --project "${PROJECT}" --queue "${QUEUE}" --year "${YEAR}" --app-config "${APP_CONFIG}" \
+   --tag "${TAG}"
 EOF

--- a/raijin_scripts/execute_wofs/run
+++ b/raijin_scripts/execute_wofs/run
@@ -1,31 +1,34 @@
 #!/bin/bash
 set -eu
 
-while [[ $# -gt 0 ]]; do
+while [[ "$#" -gt 0 ]]; do
     key="$1"
-    case ${key} in
+    case "${key}" in
         --year )                shift
-                                YEAR=$1
+                                YEAR="$1"
                                 ;;
         --product )             shift
-                                PRODUCT=$1
+                                PRODUCT="$1"
                                 ;;
         --tag )                 shift
-                                TAG=$1
+                                TAG="$1"
                                 ;;
         --dea-module )          shift
-                                MODULE=$1
+                                MODULE="$1"
                                 ;;
         --queue )               shift
-                                QUEUE=$1
+                                QUEUE="$1"
                                 ;;
         --project )             shift
-                                PROJECT=$1
+                                PROJECT="$1"
                                 ;;
         --stage )               shift
-                                STAGE=$1
+                                STAGE="$1"
                                 ;;
-        * )                     exit 1
+        * )
+          echo "Input key, '$key', did not match the expected input argument key"
+          exit 1
+          ;;
     esac
     shift
 done
@@ -52,23 +55,23 @@ while read -r LINE; do
   if [[ "$count" -eq 1 ]]
   then
       dbhostname="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   elif [[ "$count" -eq 2 ]]
   then
       dbport="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   elif [[ "$count" -eq 3 ]]
   then
       dbname="$(cut -d' ' -f2 <<<"$LINE")"
-      count=$((count+1))
+      count="$((count+1))"
   fi
 
   if [[ "${STAGE}" == "dev"  && "$LINE" == "[dea-dev]" ]]; then
-      count=$((count+1))
+      count="$((count+1))"
   fi
 
   if [[ "${STAGE}" == "prod"  && "$LINE" == "[datacube]" ]]; then
-      count=$((count+1))
+      count="$((count+1))"
   fi
 done < "$DATACUBE_CONFIG_PATH"
 


### PR DESCRIPTION
## Reason for this pull request
Duplicate files on the disc was indexed by the `sync` tool during weekly orchestration on `landsat` scenes.
Also, when `sync` tool detects that the file is no longer available on the `NCI` file system, orchestration `sync` tool updates the location in the index.
These processes created a **domino effect** resulting in large number of `duplicate datasets`/`locationless parent`/`archived parent with derived children`.

Datasets with such discrepancies needs to be reported and/or `archive`/`delete from file system`. And update the `index`.

## Proposed solutions
Following work flow is used to clean up erroneous datasets:
1) Update `execute_coherence` script to report all such erroneous datasets.
2) Automate erroneous dataset reporting via `serverless` config.
3) Validate reported datasets and archive them manually (temp solution).
4) Update and run `execute_clean` script to trash all files on disc whose index were archived.