### PR TITLE
Keep dea-public-data-inventory public

### DIFF
--- a/lambda_functions/simple_s3_pypi/README.md
+++ b/lambda_functions/simple_s3_pypi/README.md
@@ -1,13 +1,11 @@
+# Simple S3 Triggers
+
+This directory contains code for 2 x lambda functions:
+
+## Generate Listing
+
 This Lambda is responsible for maintaining a simple python package
 server hosted on S3.
-
-Originally we attempted to use s3pypi to build and upload packages,
-and also maintain the essential `index.html` pages.
-
-However, it causes a few issues. It doesn't play nicely with Fractional Cover
-which needs to build a binary package from some Fortran sources. And more importantly
-it has a very strict and hard coded restriction on package version numbers,
-which causes most of our packages to go unlisted.
 
 Rather than attempting to fix those problems. This takes a new approach,
 similar to [s3-directory-listing](https://github.com/razorjack/s3-directory-listing),
@@ -20,21 +18,26 @@ deployment tools.
 We can follow [PEP 503 - Simple Repository API](https://www.python.org/dev/peps/pep-0503/)
 and maybe eventually include extra niceties like checksum hashes.
 
+## Make Public
+
+Configured to make any object placed into `dea-public-inventory` public.
+
+It's the simplest way to make a public inventory. Objects aren't owned by the bucket owner,
+so permissions set on the bucket don't apply to the objects.
+
+
+
+
+
 ## Installation Instructions
 
-1) Deploy using serverless
 
-```bash
-    sls deploy
+```shell
+sls deploy && sls s3deploy
 ```
-
-2) Add a policy to the target bucket if public read access is required
-
-3) Add an Event to the bucket to call the lambda function
 
 
 ## Problems
 
- * _Need to
  * _Need to switch to SNS with a fanout, since can't double up on
 Events on the same bucket_

--- a/lambda_functions/simple_s3_pypi/make_public.py
+++ b/lambda_functions/simple_s3_pypi/make_public.py
@@ -1,0 +1,18 @@
+import logging
+import urllib.parse
+
+import boto3
+
+S3 = boto3.resource('s3')
+LOG = logging.getLogger()
+LOG.setLevel(logging.INFO)
+
+
+def make_public(event, context):
+    new_objects = [(record['s3']['bucket']['name'], urllib.parse.unquote(record['s3']['object']['key'])) for record in
+                   event['Records']]
+    LOG.info("Changed/new objects: %s", str(new_objects))
+    for bucket, obj in new_objects:
+        object_acl = S3.ObjectAcl(bucket, obj)
+        object_acl.put(ACL='public-read')
+    LOG.info('Made all objects public')

--- a/lambda_functions/simple_s3_pypi/serverless.yml
+++ b/lambda_functions/simple_s3_pypi/serverless.yml
@@ -25,19 +25,6 @@ provider:
 
 
   iamRoleStatements:
-#   - Effect: "Allow"
-#     Action:
-#       - "s3:ListBucket"
-#     Resource: {"Fn::Join": ["", ["arn:aws:s3:::", {"Ref": "ServerlessDeploymentBucket"}]]}
-#   - Effect: "Allow"
-#     Action:
-#       - "s3:PutObject"
-#     Resource:
-#       Fn::Join:
-#         - ""
-#         - - "arn:aws:s3:::"
-#           - "Ref": "ServerlessDeploymentBucket"
-#           - "/*"
    - Effect: "Allow"
      Action:
        - "s3:ListBucket"

--- a/lambda_functions/simple_s3_pypi/serverless.yml
+++ b/lambda_functions/simple_s3_pypi/serverless.yml
@@ -2,37 +2,48 @@ service: s3-directory-list
 
 plugins:
   - serverless-plugin-existing-s3
+  - serverless-pseudo-parameters
 
 custom:
   bucketName: datacube-core-deployment
+  inventoryBucket: dea-public-data-inventory
+
+package:
+  exclude:
+    - node_modules/**
+    - .terraform/**
+
 
 provider:
   name: aws
   runtime: python3.6
   memorySize: 128
 
-  stage: dev
+  stage: prod
   region: ap-southeast-2
+  deploymentBucket: dea-lambda
 
 
   iamRoleStatements:
+#   - Effect: "Allow"
+#     Action:
+#       - "s3:ListBucket"
+#     Resource: {"Fn::Join": ["", ["arn:aws:s3:::", {"Ref": "ServerlessDeploymentBucket"}]]}
+#   - Effect: "Allow"
+#     Action:
+#       - "s3:PutObject"
+#     Resource:
+#       Fn::Join:
+#         - ""
+#         - - "arn:aws:s3:::"
+#           - "Ref": "ServerlessDeploymentBucket"
+#           - "/*"
    - Effect: "Allow"
      Action:
        - "s3:ListBucket"
-     Resource: {"Fn::Join": ["", ["arn:aws:s3:::", {"Ref": "ServerlessDeploymentBucket"}]]}
-   - Effect: "Allow"
-     Action:
-       - "s3:PutObject"
      Resource:
-       Fn::Join:
-         - ""
-         - - "arn:aws:s3:::"
-           - "Ref": "ServerlessDeploymentBucket"
-           - "/*"
-   - Effect: "Allow"
-     Action:
-       - "s3:ListBucket"
-     Resource: "arn:aws:s3:::${self:custom.bucketName}"
+       - "arn:aws:s3:::${self:custom.bucketName}"
+       - "arn:aws:s3:::${self:custom.inventoryBucket}"
    - Effect: "Allow"
      Action:
        - "s3:GetObject"
@@ -41,7 +52,12 @@ provider:
    - Effect: "Allow"
      Action:
       - "s3:PutBucketNotification"
-     Resource: "arn:aws:s3:::${self:custom.bucketName}"
+     Resource:
+      - "arn:aws:s3:::${self:custom.bucketName}"
+      - "arn:aws:s3:::${self:custom.inventoryBucket}"
+   - Effect: "Allow"
+     Action: "s3:PutObjectAcl"
+     Resource: "arn:aws:s3:::${self:custom.inventoryBucket}"
 
 functions:
   generateListing:
@@ -52,3 +68,10 @@ functions:
           events:
             - s3:ObjectCreated:*
             - s3:ObjectRemoved:*
+  makePublic:
+    handler: make_public.make_public
+    events:
+      - existingS3:
+          bucket: ${self:custom.inventoryBucket}
+          events:
+            - s3:ObjectCreated:*

--- a/lambda_functions/simple_s3_pypi/serverless.yml
+++ b/lambda_functions/simple_s3_pypi/serverless.yml
@@ -57,7 +57,7 @@ provider:
       - "arn:aws:s3:::${self:custom.inventoryBucket}"
    - Effect: "Allow"
      Action: "s3:PutObjectAcl"
-     Resource: "arn:aws:s3:::${self:custom.inventoryBucket}"
+     Resource: "arn:aws:s3:::${self:custom.inventoryBucket}/*"
 
 functions:
   generateListing:


### PR DESCRIPTION
We have set up an (S3 Inventory)[https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html]
on the `dea-public-data` S3 bucket, and wish for it to be public.

Unfortunately, AWS doesn't provide an easy way to do this. Even if the target bucket is public,
the objects are created and owned by an AWS process, so don't inherit the permissions.

This PR adds a lambda which watches for new objects in the inventory bucket, and then
makes them public.