### PR TITLE
Stac check

### DIFF
--- a/lambda_functions/stac/serverless.yml
+++ b/lambda_functions/stac/serverless.yml
@@ -15,6 +15,13 @@ package:
     - package.json
     - package-lock.json
     - requirements.txt
+    - stac_deploy.tf
+    - terraform.*
+    - notify_to_stac_queue.py
+    - stac_check.py
+    - stac_parent_update.py
+    - stac_utils.py
+    - update_product_suite_catalogs.py
 
 custom:
   Stage: dev

--- a/lambda_functions/stac/stac_check.py
+++ b/lambda_functions/stac/stac_check.py
@@ -179,7 +179,7 @@ def test_stac_items(s3_dataset_yamls, upload_yamls_from_prod_to_dev):
 
     # We may need to wait here a bit until messages in the queue are delivered
     # This should be at least timeout of lambda
-    time.sleep(10)
+    time.sleep(300)
 
     s3_client = boto3.client('s3')
     for dts in s3_dataset_yamls:

--- a/lambda_functions/stac/stac_deploy.tf
+++ b/lambda_functions/stac/stac_deploy.tf
@@ -1,6 +1,10 @@
 provider "aws" {
   region = "ap-southeast-2"
-  profile = "devProfile"
+  profile = "prodProfile"
+}
+
+data "aws_sns_topic" "dea_public_data_topic" {
+  name = ""
 }
 
 resource "aws_sqs_queue" "stac_queue" {
@@ -20,68 +24,10 @@ resource "aws_sqs_queue_policy" "stac_queue_policy" {
       "Action": "sqs:SendMessage",
       "Resource": "arn:aws:sqs:*:*:static-stac-queue",
       "Condition": {
-        "ArnEquals": { "aws:SourceArn": "${data.aws_s3_bucket.dea_s3_bucket.arn}" }
+        "ArnEquals": { "aws:SourceArn": "${data.aws_sns_topic.dea_public_data_topic.arn}" }
       }
     }
   ]
 }
 POLICY
 }
-
-data "aws_s3_bucket" "dea_s3_bucket" {
-  bucket = "dea-public-data-dev"
-}
-
-resource "aws_s3_bucket_policy" "dea_public_data_policy" {
-  bucket = "${data.aws_s3_bucket.dea_s3_bucket.id}"
-
-  policy = <<POLICY
-{
-    "Version": "2008-10-17",
-    "Statement": [
-        {
-            "Sid": "AllowPublicRead",
-            "Effect": "Allow",
-            "Principal": "*",
-            "Action": "s3:GetObject",
-            "Resource": "arn:aws:s3:::${data.aws_s3_bucket.dea_s3_bucket.bucket}/*"
-        },
-        {
-            "Sid": "AllowPublicList",
-            "Effect": "Allow",
-            "Principal": "*",
-            "Action": "s3:ListBucket",
-            "Resource": "arn:aws:s3:::${data.aws_s3_bucket.dea_s3_bucket.bucket}"
-        },
-        {
-            "Sid": "AllowDevAcctNotificationAdd",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam::451924316694:root"
-            },
-            "Action": [
-                "s3:GetBucketLocation",
-                "s3:ListBucket",
-                "s3:GetBucketNotification",
-                "s3:PutBucketNotification"
-            ],
-            "Resource": [
-                "arn:aws:s3:::${data.aws_s3_bucket.dea_s3_bucket.bucket}",
-                "arn:aws:s3:::${data.aws_s3_bucket.dea_s3_bucket.bucket}/*"
-            ]
-        }
-    ]
-}
-POLICY
-}
-
-resource "aws_s3_bucket_notification" "yaml_notification" {
-  bucket = "${data.aws_s3_bucket.dea_s3_bucket.id}"
-
-  queue {
-    queue_arn     = "${aws_sqs_queue.stac_queue.arn}"
-    events        = ["s3:ObjectCreated:*"]
-    filter_suffix = ".yaml"
-  }
-}
-

--- a/lambda_functions/stac/stac_deploy.tf
+++ b/lambda_functions/stac/stac_deploy.tf
@@ -32,6 +32,49 @@ data "aws_s3_bucket" "dea_s3_bucket" {
   bucket = "dea-public-data-dev"
 }
 
+resource "aws_s3_bucket_policy" "dea_public_data_policy" {
+  bucket = "${data.aws_s3_bucket.dea_s3_bucket.id}"
+
+  policy = <<POLICY
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowPublicRead",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::${data.aws_s3_bucket.dea_s3_bucket.bucket}/*"
+        },
+        {
+            "Sid": "AllowPublicList",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::${data.aws_s3_bucket.dea_s3_bucket.bucket}"
+        },
+        {
+            "Sid": "AllowDevAcctNotificationAdd",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::451924316694:root"
+            },
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListBucket",
+                "s3:GetBucketNotification",
+                "s3:PutBucketNotification"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${data.aws_s3_bucket.dea_s3_bucket.bucket}",
+                "arn:aws:s3:::${data.aws_s3_bucket.dea_s3_bucket.bucket}/*"
+            ]
+        }
+    ]
+}
+POLICY
+}
+
 resource "aws_s3_bucket_notification" "yaml_notification" {
   bucket = "${data.aws_s3_bucket.dea_s3_bucket.id}"
 

--- a/lambda_functions/stac/stac_deploy.tf
+++ b/lambda_functions/stac/stac_deploy.tf
@@ -1,10 +1,16 @@
 provider "aws" {
   region = "ap-southeast-2"
-  profile = "prodProfile"
+  profile = "devProfile"
 }
 
 data "aws_sns_topic" "dea_public_data_topic" {
-  name = ""
+  name = "DEANewDataDev"
+}
+
+resource "aws_sns_topic_subscription" "stac_queue_subscription" {
+  topic_arn = "${data.aws_sns_topic.dea_public_data_topic.arn}"
+  protocol = "sqs"
+  endpoint = "${aws_sqs_queue.stac_queue.arn}"
 }
 
 resource "aws_sqs_queue" "stac_queue" {


### PR DESCRIPTION
# Reason for this PR
It was decided that `event processing pipeline` for `STAC item` processing now require feeds from an existing `SNS topic` that publishes `S3 object creation events` in an `S3` bucket. This PR updates the `terraform` script that deploy `SQS` infrastructure and the `lambda` function to do improved filtering. Further documentation updates are given in `README.md`. Batch processing scripts do not require updates. 

# Solutions
[x] No `SNS filtering` is performed since filtering based on the `message` is not available. Instead filtering is performed within the lambda function itself. 