### PR TITLE
Process s2 ard and landsat scene dataset sync in a more efficient way

### DIFF
--- a/lambda_functions/execute_ssh_command_js/handler.js
+++ b/lambda_functions/execute_ssh_command_js/handler.js
@@ -79,6 +79,48 @@ function process_s2ard_sync_command(event) {
     return command_list
 }
 
+/**
+ * Construct time range as a string.
+ */
+function event_range(year, month, date1, date2) {
+    return "'" + year + "-" + month + '-' + date1 + ' < time < '+ year + "-" + month + '-' + date2 + "'";
+}
+
+/**
+ * Construct cog conversion command and turn the entire event into an ssh execution command list.
+ */
+function process_cog_conv_command(event) {
+    var yearRange = process.env.yearrange;
+    var arr = yearRange.split("-");
+    var months = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'];
+    for(var year=arr[0]; year <= arr[1]; year++) {
+        for(var j=0; j<months.length; j++) {
+            event.time_range = event_range(year, months[j], "01", "05");
+            let command_1 = create_execution_string(event);
+            command_list.push(command_1)
+            event.time_range = event_range(year, months[j], "05", "10");
+            command_1 = create_execution_string(event);
+            command_list.push(command_1)
+            event.time_range = event_range(year, months[j], "10", "15");
+            command_1 = create_execution_string(event);
+            command_list.push(command_1)
+            event.time_range = event_range(year, months[j], "15", "20");
+            command_1 = create_execution_string(event);
+            command_list.push(command_1)
+            event.time_range = event_range(year, months[j], "20", "25");
+            command_1 = create_execution_string(event);
+            command_list.push(command_1)
+            event.time_range = event_range(year, months[j], "25", "30");
+            command_1 = create_execution_string(event);
+            command_list.push(command_1)
+            event.time_range = event_range(year, months[j], "30", "31");
+            command_1 = create_execution_string(event);
+            command_list.push(command_1)
+        }
+    }
+    return command_list
+}
+
 exports.execute_ssh_command = (event, context, callback) => {
         let req = {
                    Names: [hostkey, userkey, pkey],
@@ -142,6 +184,8 @@ exports.execute_ssh_command = (event, context, callback) => {
                  command = process_ls_sync_command(event, bPath, suffix);
             } else if (event.product == 's2_ard_granule') {
                  command = process_s2ard_sync_command(event);
+            } else if (!event.cog_product || event.cog_product === "") {
+                 command = process_cog_conv_command(event);
             } else {
                  let cmd = create_execution_string(event);
                  command.push(cmd)

--- a/lambda_functions/execute_ssh_command_js/handler.js
+++ b/lambda_functions/execute_ssh_command_js/handler.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 const SSH = require('simple-ssh');
+const path = require('path');
 var _ = require('lodash');
+var sleep = require("deasync").sleep;
 
 // Configure the SDK for Node.js
 const AWS = require("aws-sdk");
@@ -12,6 +14,8 @@ const ssm = new AWS.SSM();
 const hostkey = process.env.hostkey;
 const userkey = process.env.userkey;
 const pkey = process.env.pkey;
+var command_list = [];
+var command = [];
 
 /**
  * Turn an event into an ssh execution string.
@@ -34,12 +38,55 @@ function create_execution_string(event) {
     return compiled(event);
 }
 
+/**
+ * Construct sync path for Landsat Scenes within an event
+ * and turn the entire event into an ssh execution command list.
+ */
+function process_ls_sync_command(event, bPath, suffix) {
+    var yearRange = process.env.yearrange;
+    var arr = yearRange.split("-");
+    for(var year=arr[0]; year <= arr[1]; year++) {
+        event.path = bPath + year + "/??" + suffix;
+        event.year = year;
+        let cmd = create_execution_string(event);
+        command_list.push(cmd)
+    }
+    return command_list
+}
+
+/**
+ * Construct sync path for Sentinel 2 ARD granules within an event
+ * and turn the entire event into an ssh execution command list.
+ *
+ * The directory structure for S2 ARD granules is packaged into a single
+ * directory (/g/data/if87/datacube/002/S2_MSI_ARD/packaged) making it
+ * difficult for orchestration of past and future years. Hence this new function
+ * to take care of this dependency.
+ */
+function process_s2ard_sync_command(event) {
+    var basePath = process.env.basepath;
+    var yearRange = process.env.yearrange;
+    var arr = yearRange.split("-");
+    var months = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'];
+    for(var year=arr[0]; year <= arr[1]; year++) {
+        for(var j=0; j<months.length; j++) {
+            event.path = basePath + year + "-" + months[j] + "-*/*/";
+            event.year = year;
+            let cmd = create_execution_string(event);
+            command_list.push(cmd)
+        }
+    }
+    return command_list
+}
+
 exports.execute_ssh_command = (event, context, callback) => {
         let req = {
                    Names: [hostkey, userkey, pkey],
                    WithDecryption: true
         };
         let keys = ssm.getParameters(req).promise();
+        command_list = [];  // Empty command list before starting command execution
+        command = [];  // Empty command variable before starting command execution
 
         keys.catch(function(err) {
             console.log(err);
@@ -61,29 +108,69 @@ exports.execute_ssh_command = (event, context, callback) => {
             console.log(`Host key: ${params[hostkey]}`);
             console.log(`User key: ${params[userkey]}`);
 
-            let command = create_execution_string(event);
+            if (event.product == 'ls8_nbar_scene') {
+                 let bPath = process.env.ls8_nbar_nbart_basepath;
+                 let suffix = process.env.nbar_suffix;
+                 command = process_ls_sync_command(event, bPath, suffix);
+            } else if (event.product == 'ls8_nbart_scene') {
+                 let bPath = process.env.ls8_nbar_nbart_basepath;
+                 let suffix = process.env.nbart_suffix;
+                 command = process_ls_sync_command(event, bPath, suffix);
+            } else if (event.product == 'ls7_nbar_scene') {
+                 let bPath = process.env.ls7_nbar_nbart_basepath;
+                 let suffix = process.env.nbar_suffix;
+                 command = process_ls_sync_command(event, bPath, suffix);
+            } else if (event.product == 'ls7_nbart_scene') {
+                 let bPath = process.env.ls7_nbar_nbart_basepath;
+                 let suffix = process.env.nbart_suffix;
+                 command = process_ls_sync_command(event, bPath, suffix);
+            } else if (event.product == 'ls8_pq_scene') {
+                 let bPath = process.env.ls8_pq_basepath;
+                 let suffix = process.env.pq_suffix;
+                 command = process_ls_sync_command(event, bPath, suffix);
+            } else if (event.product == 'ls7_pq_scene') {
+                 let bPath = process.env.ls7_pq_basepath;
+                 let suffix = process.env.pq_suffix;
+                 command = process_ls_sync_command(event, bPath, suffix);
+            } else if (event.product == 'ls8_pq_legacy_scene') {
+                 let bPath = process.env.ls8_pq_legacy_basepath;
+                 let suffix = process.env.pq_legacy_suffix;
+                 command = process_ls_sync_command(event, bPath, suffix);
+            } else if (event.product == 'ls7_pq_legacy_scene') {
+                 let bPath = process.env.ls7_pq_legacy_basepath;
+                 let suffix = process.env.pq_legacy_suffix;
+                 command = process_ls_sync_command(event, bPath, suffix);
+            } else if (event.product == 's2_ard_granule') {
+                 command = process_s2ard_sync_command(event);
+            } else {
+                 let cmd = create_execution_string(event);
+                 command.push(cmd)
+            }
 
-            ssh
-               .exec(command, {
-                     exit: (code, stdout, stderr) => {
-                        if (code == 0) {
-                                         console.log(`Executing: ${command}`);
-                                         console.log(`STDOUT: ${stdout}`);
-                                         console.log(`SSH returncode: ${code}`);
-                                         const response = { statusCode: 0, body: 'SSH command executed.' };
-                                         // Return success with information back to the caller
-                                         callback(null, response);
-                        } else {
-                                   console.log(`STDERR: ${stderr}`);
-                                   console.log(`SSH returncode: ${code}`);
-                                   //  Return error with error information back to the caller
-                                   callback(`Failed to execute, ${command}, command`);
-                        }
-                     }
+            for (var i=0; i < command.length; i++) {
+                sleep(1000);  // Delay for 1 second before executing new command
+                ssh
+                   .exec(command[i], {
+                         exit: (code, stdout, stderr) => {
+                            if (code == 0) {
+                                            console.log(`Executing: ${command[i]}`);
+                                            console.log(`STDOUT: ${stdout}`);
+                                            console.log(`SSH returncode: ${code}`);
+                                            const response = { statusCode: 0, body: 'SSH command executed.' };
+                                            // Return success with information back to the caller
+                                            callback(null, response);
+                            } else {
+                                     console.log(`STDERR: ${stderr}`);
+                                     console.log(`SSH returncode: ${code}`);
+                                     //  Return error with error information back to the caller
+                                     callback(`Failed to execute, ${command[i]}, command`);
+                            }
+                         }
                    })
-               .start({
-                   success: () => console.log(`Successfully connected to ${params[hostkey]}`),
-                   fail: (err) => console.log(`Failed to connect to ${params[hostkey]}: ${err}`)
-               });
+                .start({
+                        success: () => console.log(`Successfully connected to ${params[hostkey]}`),
+                        fail: (err) => console.log(`Failed to connect to ${params[hostkey]}: ${err}`)
+                });
+             }
         });
 };

--- a/lambda_functions/execute_ssh_command_js/package.json
+++ b/lambda_functions/execute_ssh_command_js/package.json
@@ -5,7 +5,8 @@
   "main": "handler.js",
   "dependencies": {
     "lodash": "^4.17.10",
-    "simple-ssh": "^1.0.0"
+    "simple-ssh": "^1.0.0",
+    "deasync": "^0.1.14"
   },
   "devDependencies": {
     "serverless-pseudo-parameters": "^1.6.0"

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -74,7 +74,7 @@ functions:
   execute_sync:
     # trasharchived is set to 'yes' only for the albers products and not for the scenes
     handler: handler.execute_ssh_command
-    description: Sync landsat 7/8 scenes
+    description: Sync Landsat 7/8 Scenes (NBAR/NBART/PQ/PQ_LEGACY Scenes)
     environment:
       cmd: 'execute_sync --dea-module ${self:provider.environment.DEA_MODULE}
                          --queue ${self:provider.environment.QUEUE}
@@ -84,79 +84,106 @@ functions:
                          --path <%= path %>
                          --product <%= product %>
                          --trasharchived <%= trasharchived %>'
+      yearrange: '2016-2019'
+      ls8_nbar_nbart_basepath: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/'
+      ls8_pq_basepath: '/g/data/rs0/scenes/pq-scenes-tmp/ls8/'
+      ls8_pq_legacy_basepath: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls8/'
+      ls7_nbar_nbart_basepath: '/g/data/rs0/scenes/nbar-scenes-tmp/ls7/'
+      ls7_pq_basepath: '/g/data/rs0/scenes/pq-scenes-tmp/ls7/'
+      ls7_pq_legacy_basepath: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls7/'
+      nbar_suffix: '/output/nbar/'
+      nbart_suffix: '/output/nbart/'
+      pq_suffix: '/output/pqa/'
+      pq_legacy_suffix: '/output/pqa/'
     events:
       - schedule:
           rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
           enabled: true
           input:
-            year: 2018
-            product: ls8_pq_scene
-            path: '/g/data/rs0/scenes/pq-scenes-tmp/ls8/2018/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
-          enabled: true
-          input:
-            year: 2018
-            product: ls8_pq_legacy_scene
-            path: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls8/2018/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
-          enabled: true
-          input:
-            year: 2018
-            product: ls8_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/??/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
-          enabled: true
-          input:
-            year: 2018
             product: ls8_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/2018/??/output/nbar/'
             trasharchived: no
+            year: 1234  # Actual year shall be updated within lambda function handler
+            path: ""  # Path shall be updated within lambda function handler
       - schedule:
           rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
           enabled: true
           input:
-            year: 2018
-            product: ls7_pq_scene
-            path: '/g/data/rs0/scenes/pq-scenes-tmp/ls7/2018/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
-          enabled: true
-          input:
-            year: 2018
-            product: ls7_pq_legacy_scene
-            path: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls7/2018/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
-          enabled: true
-          input:
-            year: 2018
-            product: ls7_nbart_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls7/2018/??/output/nbart/'
-            trasharchived: no
-      - schedule:
-          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
-          enabled: true
-          input:
-            year: 2018
             product: ls7_nbar_scene
-            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls7/2018/??/output/nbar/'
             trasharchived: no
+            year: 1234  # Actual year shall be updated within lambda function handler
+            path: ""  # Path shall be updated within lambda function handler
+      - schedule:
+          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: ls8_nbart_scene
+            trasharchived: no
+            year: 1234  # Actual year shall be updated within lambda function handler
+            path: ""  # Path shall be updated within lambda function handler
+      - schedule:
+          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: ls7_nbart_scene
+            trasharchived: no
+            year: 1234  # Actual year shall be updated within lambda function handler
+            path: ""  # Path shall be updated within lambda function handler
+      - schedule:
+          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: ls8_pq_scene
+            trasharchived: no
+            year: 1234  # Actual year shall be updated within lambda function handler
+            path: ""  # Path shall be updated within lambda function handler
+      - schedule:
+          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: ls7_pq_scene
+            trasharchived: no
+            year: 1234  # Actual year shall be updated within lambda function handler
+            path: ""  # Path shall be updated within lambda function handler
+      - schedule:
+          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: ls8_pq_legacy_scene
+            trasharchived: no
+            year: 1234  # Actual year shall be updated within lambda function handler
+            path: ""  # Path shall be updated within lambda function handler
+      - schedule:
+          rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: ls7_pq_legacy_scene
+            trasharchived: no
+            year: 1234  # Actual year shall be updated within lambda function handler
+            path: ""  # Path shall be updated within lambda function handler
+  execute_s2ard_sync:
+    # trasharchived is set to 'yes' only for the albers products and not for the scenes
+    handler: handler.execute_ssh_command
+    description: Sync Sentinal 2 ARD Granules
+    environment:
+      cmd: 'execute_sync --dea-module ${self:provider.environment.DEA_MODULE}
+                         --queue ${self:provider.environment.QUEUE}
+                         --project ${self:provider.environment.PROJECT}
+                         --stage ${self:custom.Stage}
+                         --year <%= year %>
+                         --path <%= path %>
+                         --product <%= product %>
+                         --trasharchived <%= trasharchived %>'
+      basepath: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+      yearrange: '2015-2019'
+    events:
       - schedule:
           rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
           enabled: true
           input:
-            year: 2015_2018
             product: s2_ard_granule
-            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/*/'
             trasharchived: no
+            year: 2018  # Actual year shall be updated within lambda function handler
+            path: ""  # Path shall be updated within lambda function handler
   execute_ingest:
     handler: handler.execute_ssh_command
     description: Execute dea-submit-ingest qsub tool to ingest datasets to the database


### PR DESCRIPTION
# Request for this pull request
Sentinel 2 ARD granules for all the years are packaged into one single directory as follows:
`/g/data/if87/datacube/002/S2_MSI_ARD/packaged`.

This breaks the orchestration process for `dea-sync` on S2 ard products. And would add more manual editing of serverless configuration file whenever new granules are packaged within the `packaged` directory.

# Proposed solution

1. Update `handler.js` function to expand `path` `glob` based on process environment variables and then pass the same to the `ssh` execution command string.
2. Add a delay of `1s` before execution new `ssh` command. This is done to ensure that `dea-sync` does not fail while accessing same cache file when we schedule all the `ssh` command string without any delay.
3. Update  `handler.js` function for processing `Landsat` scenes in lines with `S2 ARD Granule` changes.