### PR TITLE
Automate wofs cog

### DIFF
--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -360,3 +360,19 @@ functions:
             copy_parent_dir_count: 0  # IGNORED FOR L2
             level1_dir: /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C
             obs_year: previous
+  execute_cog_conversion:
+    handler: handler.execute_ssh_command
+    description: Execute COG-Conversion process for the specified product and upload the files back to S3
+    environment:
+      cmd: 'execute_cog_conversion --dea-module ${self:provider.environment.DEA_MODULE}
+                                   --queue ${self:provider.environment.QUEUE}
+                                   --project ${self:provider.environment.PROJECT}
+                                   --product <%= product %>
+                                   --time-range <%= time_range %>'
+    events:
+      - schedule:
+          rate: cron(00 13 ? * TUE *)  # Run every Tuesday, at 11:00 pm Canberra time
+          enabled: false
+          input:
+            product: wofs_albers
+            time_range: '2018-11-30 < time < 2018-12-01'

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -376,5 +376,5 @@ functions:
           rate: cron(00 13 ? * TUE *)  # Run every Tuesday, at 11:00 pm Canberra time
           enabled: false
           input:
-            product: wofs_albers
+            cog_product: wofs_albers
             time_range: ""  # time range shall be updated within lambda function handler

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -31,7 +31,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs6.10
-  timeout: 300  # 5 minutes. Default is 6 seconds
+  timeout: 600  # 10 minutes. Default is 6 seconds
   profile: ${self:custom.profiles.${self:custom.Stage}}
   environment:
     hostkey: 'orchestrator.raijin.users.default.host'
@@ -369,10 +369,12 @@ functions:
                                    --project ${self:provider.environment.PROJECT}
                                    --product <%= product %>
                                    --time-range <%= time_range %>'
+      # Max configurable years is 8 years due to lambda function timeout limitation
+      yearrange: '2011-2018'
     events:
       - schedule:
           rate: cron(00 13 ? * TUE *)  # Run every Tuesday, at 11:00 pm Canberra time
           enabled: false
           input:
             product: wofs_albers
-            time_range: '2018-11-30 < time < 2018-12-01'
+            time_range: ""  # time range shall be updated within lambda function handler

--- a/raijin_scripts/execute_cog_conversion/run
+++ b/raijin_scripts/execute_cog_conversion/run
@@ -28,8 +28,8 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-WORKDIR=/g/data/v10/work/cog_conversion/"$PRODUCT"
-SUBMISSION_LOG="$WORKDIR"/Cog_$(date '+%F_%H_%m_%s').log
+WORKDIR=/g/data/v10/work/cog_conversion/"$PRODUCT"/$(date '+%F_%H_%m_%s')
+SUBMISSION_LOG="$WORKDIR"/Cog_Submission.log
 
 mkdir -p "${WORKDIR}"
 echo "Start time: " "$(date '+%F-%T')" > "$SUBMISSION_LOG"
@@ -54,9 +54,7 @@ echo "Starting Cog-Conversion process......"
 ##################################################################################################
 # Qsub cog-convert process
 ##################################################################################################
-python3 "$HOME"/COG-Conversion/streamer/streamer.py --help
-
-python3 "$HOME"/COG-Conversion/streamer/streamer.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT} -p ${PRODUCT} \
---walltime 20 --time-range ${RANGE_EXP}
+python3 "$HOME"/COG-Conversion/converter/cog_conv_app.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT} -p ${PRODUCT} \
+--walltime 20 --output-dir ${WORKDIR} --time-range ${RANGE_EXP}
 
 EOF

--- a/raijin_scripts/execute_cog_conversion/run
+++ b/raijin_scripts/execute_cog_conversion/run
@@ -57,6 +57,6 @@ echo "Starting Cog-Conversion process......"
 python3 "$HOME"/COG-Conversion/streamer/streamer.py --help
 
 python3 "$HOME"/COG-Conversion/streamer/streamer.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT} -p ${PRODUCT} \
---time-range ${RANGE_EXP}
+--walltime 20 --time-range ${RANGE_EXP}
 
 EOF

--- a/raijin_scripts/execute_cog_conversion/run
+++ b/raijin_scripts/execute_cog_conversion/run
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -eu
+
+while [[ "$#" -gt 0 ]]; do
+    key="$1"
+    case "${key}" in
+        --dea-module )          shift
+                                MODULE="$1"
+                                ;;
+        --queue )               shift
+                                QUEUE="$1"
+                                ;;
+        --project )             shift
+                                PROJECT="$1"
+                                ;;
+        --product )             shift
+                                PRODUCT="$1"
+                                ;;
+        --time-range )          shift
+                                RANGE_EXP="'$*'"
+                                break # Last input argument and hence exiting while loop
+                                ;;
+        * )
+          echo "Input key, '$key', did not match the expected input argument key"
+          exit 1
+          ;;
+    esac
+    shift
+done
+
+WORKDIR=/g/data/v10/work/cog_conversion/"$PRODUCT"
+SUBMISSION_LOG="$WORKDIR"/Cog_$(date '+%F_%H_%m_%s').log
+
+mkdir -p "${WORKDIR}"
+echo "Start time: " "$(date '+%F-%T')" > "$SUBMISSION_LOG"
+
+module use /g/data/v10/public/modules/modulefiles
+module load "${MODULE}"
+
+cd "${WORKDIR}"
+
+nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 << EOF &
+echo "Logging into: ${SUBMISSION_LOG}"
+echo ""
+echo Loading module ${MODULE}
+echo ""
+
+# Check if we can connect to the database
+datacube -vv system check
+
+echo ""
+echo "Starting Cog-Conversion process......"
+
+##################################################################################################
+# Qsub cog-convert process
+##################################################################################################
+python3 "$HOME"/COG-Conversion/streamer/streamer.py --help
+
+python3 "$HOME"/COG-Conversion/streamer/streamer.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT} -p ${PRODUCT} \
+--time-range ${RANGE_EXP}
+
+EOF

--- a/scripts/git_pull
+++ b/scripts/git_pull
@@ -9,10 +9,10 @@ cd "$SCRIPT_DIR" || exit 1  # Changes home folder to be in repo
 
 ssh-agent bash -c "ssh-add $PATH_TO_SSH_KEY; git checkout production; git reset --hard origin/production; git pull"
 
-if [ ! -d $COG_CONV_DIR ]; then
-  cd "$HOME"
+if [ ! -d "$COG_CONV_DIR" ]; then
+  cd "$HOME" || exit 1  # Changes home folder to be in repo
   ssh-agent bash -c "ssh-add $PATH_TO_SSH_KEY; git clone $GIT_REPO;"
 fi
 
-cd "$COG_CONV_DIR"
+cd "$COG_CONV_DIR" || exit 1  # Changes home folder to be in repo
 ssh-agent bash -c "ssh-add $PATH_TO_SSH_KEY; git checkout master; git reset --hard origin/master; git pull"

--- a/scripts/git_pull
+++ b/scripts/git_pull
@@ -2,7 +2,17 @@
 
 PATH_TO_SSH_KEY="$HOME/.ssh/id_rsa"
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+GIT_REPO="https://github.com/GeoscienceAustralia/COG-Conversion.git"
+COG_CONV_DIR="$HOME/COG-Conversion"
 
 cd "$SCRIPT_DIR" || exit 1  # Changes home folder to be in repo
 
 ssh-agent bash -c "ssh-add $PATH_TO_SSH_KEY; git checkout production; git reset --hard origin/production; git pull"
+
+if [ ! -d $COG_CONV_DIR ]; then
+  cd "$HOME"
+  ssh-agent bash -c "ssh-add $PATH_TO_SSH_KEY; git clone $GIT_REPO;"
+fi
+
+cd "$COG_CONV_DIR"
+ssh-agent bash -c "ssh-add $PATH_TO_SSH_KEY; git checkout master; git reset --hard origin/master; git pull"


### PR DESCRIPTION
# Request for this pull request
Automate `cog conversion` for `WOfS` product.

# Proposed solutions
- Update serverless config file to schedule new raijin script, `execute_cog_conversion`.
- Add new raijin script to `qsub` and convert `netCDF` files to `COG` format.
- Update `scripts/git_pull` script to fetch latest revision of `COG-Conversion` git repository.