### PR TITLE
Remove multiple ssh command executions

### DIFF
--- a/lambda_functions/execute_ssh_command_js/handler.js
+++ b/lambda_functions/execute_ssh_command_js/handler.js
@@ -221,7 +221,7 @@ exports.execute_ssh_command = (event, context, callback) => {
                   }
                });
             });
-            console.log(`${CMDList.length} commands will be executed`);
+            console.log(`${CMDList.length} command/s will be executed`);
             ssh.start({
                        success: () => console.log(`Successfully connected to ${params[hostkey]}`),
                        fail: (err) => console.log(`Failed to connect to ${params[hostkey]}: ${err}`)

--- a/lambda_functions/execute_ssh_command_js/handler.js
+++ b/lambda_functions/execute_ssh_command_js/handler.js
@@ -16,7 +16,6 @@ const ssm = new AWS.SSM();
 const hostkey = process.env.hostkey;
 const userkey = process.env.userkey;
 const pkey = process.env.pkey;
-var command_list = [];
 var CMDList = [];
 
 /**
@@ -51,9 +50,8 @@ function process_ls_sync_command(event, bPath, suffix) {
         event.path = bPath + year + "/??" + suffix;
         event.year = year;
         let ls_cmd = create_execution_string(event);
-        command_list.push(ls_cmd)
+        CMDList.push(ls_cmd)
     }
-    return command_list
 }
 
 /**
@@ -75,10 +73,9 @@ function process_s2ard_sync_command(event) {
             event.path = basePath + year + "-" + months[j] + "-*/*/";
             event.year = year;
             let s2cmd = create_execution_string(event);
-            command_list.push(s2cmd)
+            CMDList.push(s2cmd)
         }
     }
-    return command_list
 }
 
 /**
@@ -99,28 +96,27 @@ function process_cog_conv_command(event) {
         for(var j=0; j<months.length; j++) {
             event.time_range = event_range(year, months[j], "01", "05");
             let command_1 = create_execution_string(event);
-            command_list.push(command_1)
+            CMDList.push(command_1)
             event.time_range = event_range(year, months[j], "05", "10");
             command_1 = create_execution_string(event);
-            command_list.push(command_1)
+            CMDList.push(command_1)
             event.time_range = event_range(year, months[j], "10", "15");
             command_1 = create_execution_string(event);
-            command_list.push(command_1)
+            CMDList.push(command_1)
             event.time_range = event_range(year, months[j], "15", "20");
             command_1 = create_execution_string(event);
-            command_list.push(command_1)
+            CMDList.push(command_1)
             event.time_range = event_range(year, months[j], "20", "25");
             command_1 = create_execution_string(event);
-            command_list.push(command_1)
+            CMDList.push(command_1)
             event.time_range = event_range(year, months[j], "25", "30");
             command_1 = create_execution_string(event);
-            command_list.push(command_1)
+            CMDList.push(command_1)
             event.time_range = event_range(year, months[j], "30", "31");
             command_1 = create_execution_string(event);
-            command_list.push(command_1)
+            CMDList.push(command_1)
         }
     }
-    return command_list
 }
 
 exports.execute_ssh_command = (event, context, callback) => {
@@ -129,7 +125,6 @@ exports.execute_ssh_command = (event, context, callback) => {
                    WithDecryption: true
         };
         let keys = ssm.getParameters(req).promise();
-        command_list = [];  // Empty command list before starting command execution
         CMDList = [];  // Empty command variable before starting command execution
 
         keys.catch(function(err) {
@@ -155,47 +150,46 @@ exports.execute_ssh_command = (event, context, callback) => {
             if (event.product == 'ls8_nbar_scene') {
                  let bPath = process.env.ls8_nbar_nbart_basepath;
                  let suffix = process.env.nbar_suffix;
-                 CMDList = process_ls_sync_command(event, bPath, suffix);
+                 process_ls_sync_command(event, bPath, suffix);
             } else if (event.product == 'ls8_nbart_scene') {
                  let bPath = process.env.ls8_nbar_nbart_basepath;
                  let suffix = process.env.nbart_suffix;
-                 CMDList = process_ls_sync_command(event, bPath, suffix);
+                 process_ls_sync_command(event, bPath, suffix);
             } else if (event.product == 'ls7_nbar_scene') {
                  let bPath = process.env.ls7_nbar_nbart_basepath;
                  let suffix = process.env.nbar_suffix;
-                 CMDList = process_ls_sync_command(event, bPath, suffix);
+                 process_ls_sync_command(event, bPath, suffix);
             } else if (event.product == 'ls7_nbart_scene') {
                  let bPath = process.env.ls7_nbar_nbart_basepath;
                  let suffix = process.env.nbart_suffix;
-                 CMDList = process_ls_sync_command(event, bPath, suffix);
+                 process_ls_sync_command(event, bPath, suffix);
             } else if (event.product == 'ls8_pq_scene') {
                  let bPath = process.env.ls8_pq_basepath;
                  let suffix = process.env.pq_suffix;
-                 CMDList = process_ls_sync_command(event, bPath, suffix);
+                 process_ls_sync_command(event, bPath, suffix);
             } else if (event.product == 'ls7_pq_scene') {
                  let bPath = process.env.ls7_pq_basepath;
                  let suffix = process.env.pq_suffix;
-                 CMDList = process_ls_sync_command(event, bPath, suffix);
+                 process_ls_sync_command(event, bPath, suffix);
             } else if (event.product == 'ls8_pq_legacy_scene') {
                  let bPath = process.env.ls8_pq_legacy_basepath;
                  let suffix = process.env.pq_legacy_suffix;
-                 CMDList = process_ls_sync_command(event, bPath, suffix);
+                 process_ls_sync_command(event, bPath, suffix);
             } else if (event.product == 'ls7_pq_legacy_scene') {
                  let bPath = process.env.ls7_pq_legacy_basepath;
                  let suffix = process.env.pq_legacy_suffix;
-                 CMDList = process_ls_sync_command(event, bPath, suffix);
+                 process_ls_sync_command(event, bPath, suffix);
             } else if (event.product == 's2_ard_granule') {
-                 CMDList = process_s2ard_sync_command(event);
+                 process_s2ard_sync_command(event);
             } else if (typeof event.cog_product !== 'undefined') {
                  // event.cog_product is defined
                  console.log(`event.cog_product is defined`);
-                 CMDList = process_cog_conv_command(event);
+                 process_cog_conv_command(event);
             } else {
                  let cmd = create_execution_string(event);
                  CMDList.push(cmd)
             }
 
-            CMDList.length = CMDList.length;
             UNDERSCORE.each(CMDList, function(this_command, i){
                ssh.exec(this_command, {
                   exit: (code, stdout, stderr) => {

--- a/lambda_functions/execute_ssh_command_js/handler.js
+++ b/lambda_functions/execute_ssh_command_js/handler.js
@@ -80,8 +80,8 @@ function process_s2ard_sync_command(event) {
 /**
  * Construct time range as a string.
  */
-function event_range(year, month, date1, date2) {
-    return "'" + year + "-" + month + '-' + date1 + ' < time < '+ year + "-" + month + '-' + date2 + "'";
+function event_range(year, month) {
+    return "'" + year + "-" + month + ' < time < '+ year + "-" + month + "'";
 }
 
 /**
@@ -93,26 +93,8 @@ function process_cog_conv_command(event) {
     var months = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'];
     for(var year=arr[0]; year <= arr[1]; year++) {
         for(var j=0; j<months.length; j++) {
-            event.time_range = event_range(year, months[j], "01", "05");
+            event.time_range = event_range(year, months[j]);
             let command_1 = create_execution_string(event);
-            CMDList.push(command_1)
-            event.time_range = event_range(year, months[j], "05", "10");
-            command_1 = create_execution_string(event);
-            CMDList.push(command_1)
-            event.time_range = event_range(year, months[j], "10", "15");
-            command_1 = create_execution_string(event);
-            CMDList.push(command_1)
-            event.time_range = event_range(year, months[j], "15", "20");
-            command_1 = create_execution_string(event);
-            CMDList.push(command_1)
-            event.time_range = event_range(year, months[j], "20", "25");
-            command_1 = create_execution_string(event);
-            CMDList.push(command_1)
-            event.time_range = event_range(year, months[j], "25", "30");
-            command_1 = create_execution_string(event);
-            CMDList.push(command_1)
-            event.time_range = event_range(year, months[j], "30", "31");
-            command_1 = create_execution_string(event);
             CMDList.push(command_1)
         }
     }

--- a/lambda_functions/execute_ssh_command_js/handler.js
+++ b/lambda_functions/execute_ssh_command_js/handler.js
@@ -2,7 +2,6 @@
 'use strict';
 const SSH = require('simple-ssh');
 const path = require('path');
-const UNDERSCORE = require("underscore");
 
 var _ = require('lodash');
 var sleep = require("deasync").sleep;
@@ -190,7 +189,7 @@ exports.execute_ssh_command = (event, context, callback) => {
                  CMDList.push(cmd)
             }
 
-            UNDERSCORE.each(CMDList, function(this_command, i){
+            _.each(CMDList, function(this_command, i){
                ssh.exec(this_command, {
                   exit: (code, stdout, stderr) => {
                        var response = { statusCode: code, body: 'SSH command executed.' };

--- a/lambda_functions/execute_ssh_command_js/package.json
+++ b/lambda_functions/execute_ssh_command_js/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "lodash": "^4.17.10",
     "simple-ssh": "^1.0.0",
-    "deasync": "^0.1.14",
+    "deasync": "^0.1.14"
   },
   "devDependencies": {
     "serverless-pseudo-parameters": "^1.6.0"

--- a/lambda_functions/execute_ssh_command_js/package.json
+++ b/lambda_functions/execute_ssh_command_js/package.json
@@ -7,7 +7,6 @@
     "lodash": "^4.17.10",
     "simple-ssh": "^1.0.0",
     "deasync": "^0.1.14",
-    "underscore": "^1.9.1"
   },
   "devDependencies": {
     "serverless-pseudo-parameters": "^1.6.0"

--- a/lambda_functions/execute_ssh_command_js/package.json
+++ b/lambda_functions/execute_ssh_command_js/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "lodash": "^4.17.10",
     "simple-ssh": "^1.0.0",
-    "deasync": "^0.1.14"
+    "deasync": "^0.1.14",
+    "underscore": "^1.9.1"
   },
   "devDependencies": {
     "serverless-pseudo-parameters": "^1.6.0"

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -394,13 +394,13 @@ functions:
       cmd: 'execute_cog_conversion --dea-module ${self:provider.environment.DEA_MODULE}
                                    --queue ${self:provider.environment.QUEUE}
                                    --project ${self:provider.environment.PROJECT}
-                                   --product <%= product %>
+                                   --cog-product <%= cog_product %>
                                    --time-range <%= time_range %>'
       # Max configurable years is 8 years due to lambda function timeout limitation
-      yearrange: '2011-2018'
+      yearrange: '2018-2018'
     events:
       - schedule:
-          rate: cron(00 13 ? * TUE *)  # Run every Tuesday, at 11:00 pm Canberra time
+          rate: cron(30 10 ? * TUE *)  # Run every Tuesday, at 08:30 pm Canberra time
           enabled: false
           input:
             cog_product: wofs_albers

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -182,7 +182,7 @@ functions:
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: 2018  # Actual year shall be updated within lambda function handler
+            year: 2019  # Actual year shall be updated within lambda function handler
             path: ""  # Path shall be updated within lambda function handler
   execute_ingest:
     handler: handler.execute_ssh_command
@@ -199,37 +199,37 @@ functions:
           rate: cron(15 10 ? * SAT *)  # Run every Saturday, at 08:15 pm Canberra time
           enabled: true
           input:
-            year: 2018
+            year: 2019
             product: ls8_nbart_albers
       - schedule:
           rate: cron(15 10 ? * SAT *)  # Run every Saturday, at 08:15 pm Canberra time
           enabled: true
           input:
-            year: 2018
+            year: 2019
             product: ls8_nbar_albers
       - schedule:
           rate: cron(15 10 ? * SAT *)  # Run every Saturday, at 08:15 pm Canberra time
           enabled: true
           input:
-            year: 2018
+            year: 2019
             product: ls8_pq_albers
       - schedule:
           rate: cron(15 10 ? * SAT *)  # Run every Saturday, at 08:15 pm Canberra time
           enabled: true
           input:
-            year: 2018
+            year: 2019
             product: ls7_nbart_albers
       - schedule:
           rate: cron(15 10 ? * SAT *)  # Run every Saturday, at 08:15 pm Canberra time
           enabled: true
           input:
-            year: 2018
+            year: 2019
             product: ls7_nbar_albers
       - schedule:
           rate: cron(15 10 ? * SAT *)  # Run every Saturday, at 08:15 pm Canberra time
           enabled: true
           input:
-            year: 2018
+            year: 2019
             product: ls7_pq_albers
   execute_fractional_cover:
     handler: handler.execute_ssh_command
@@ -247,14 +247,14 @@ functions:
           rate: cron(15 10 ? * SUN *)  # Run every Sunday, at 08:15 pm Canberra time
           enabled: true
           input:
-            year: 2018
+            year: 2019
             product: ls8_fc_albers
             tag: 'ls8_fc2018'
       - schedule:
           rate: cron(15 10 ? * SUN *)  # Run every Sunday, at 08:15 pm Canberra time
           enabled: true
           input:
-            year: 2018
+            year: 2019
             product: ls7_fc_albers
             tag: 'ls7_fc2018'
   execute_wofs:
@@ -273,9 +273,9 @@ functions:
           rate: cron(20 10 ? * SUN *)  # Run every Sunday, at 08:20 pm Canberra time
           enabled: true
           input:
-            year: 2018
+            year: 2019
             product: wofs_albers
-            tag: '2018'
+            tag: '2019'
   execute_coherence:
     # Note: Keep `--timequery` argument as the last argument in the environment.cmd
     handler: handler.execute_ssh_command
@@ -291,7 +291,7 @@ functions:
           rate: cron(00 09 ? * TUE *)  # Run every Tuesday, at 07:00 pm Canberra time
           enabled: true
           input:
-            timequery: 'time in 2018'
+            timequery: 'time in 2019'
             product: all
   execute_notify_on_error_ds:
     handler: handler.execute_ssh_command
@@ -397,7 +397,7 @@ functions:
                                    --cog-product <%= cog_product %>
                                    --time-range <%= time_range %>'
       # Max configurable years is 8 years due to lambda function timeout limitation
-      yearrange: '2018-2018'
+      yearrange: '2017-2018'
     events:
       - schedule:
           rate: cron(30 10 ? * TUE *)  # Run every Tuesday, at 08:30 pm Canberra time

--- a/raijin_scripts/execute_cog_conversion/run
+++ b/raijin_scripts/execute_cog_conversion/run
@@ -13,7 +13,7 @@ while [[ "$#" -gt 0 ]]; do
         --project )             shift
                                 PROJECT="$1"
                                 ;;
-        --product )             shift
+        --cog-product )         shift
                                 PRODUCT="$1"
                                 ;;
         --time-range )          shift


### PR DESCRIPTION
# Proposed changes
1) Update `lambda` function to prevent duplicate execution of `ssh` `command` with the help of `underscore` `npm` package.
2) Fix typo in `raijin_scripts/execute_cog_conversion/run` script and `lambda_functions/execute_ssh_command_js/serverless.yml` file .
3) Add `underscore` `npm` package in `lambda_functions/execute_ssh_command_js/package.json` file.
