### PR TITLE
Clean lambda function

### DIFF
--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -480,8 +480,7 @@ functions:
     events:
       - schedule:
           rate: cron(30 10 ? * MON *)  # Run every Monday, at 08:30 pm Canberra time
-          enabled: false
+          enabled: true
           input:
             cog_product: wofs_albers
-            # Max configurable years is 8 years due to lambda function timeout limitation
-            time_range: '2017-2019'
+            time_range: '1986-2019'

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -74,27 +74,16 @@ functions:
   execute_sync:
     # trasharchived is set to 'yes' only for the albers products and not for the scenes
     handler: handler.execute_ssh_command
-    description: Sync Landsat 7/8 Scenes (NBAR/NBART/PQ/PQ_LEGACY Scenes)
+    description: Sync Landsat 7/8 Scenes (NBAR/NBART/PQ/PQ_LEGACY Scenes) and Sentinal 2 ARD Granules
     environment:
       cmd: 'execute_sync --dea-module ${self:provider.environment.DEA_MODULE}
                          --queue ${self:provider.environment.QUEUE}
                          --project ${self:provider.environment.PROJECT}
-                         --stage ${self:custom.Stage}
                          --year <%= year %>
                          --path <%= path %>
+                         --suffixpath <%= suffixpath %>
                          --product <%= product %>
                          --trasharchived <%= trasharchived %>'
-      yearrange: '2016-2019'
-      ls8_nbar_nbart_basepath: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/'
-      ls8_pq_basepath: '/g/data/rs0/scenes/pq-scenes-tmp/ls8/'
-      ls8_pq_legacy_basepath: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls8/'
-      ls7_nbar_nbart_basepath: '/g/data/rs0/scenes/nbar-scenes-tmp/ls7/'
-      ls7_pq_basepath: '/g/data/rs0/scenes/pq-scenes-tmp/ls7/'
-      ls7_pq_legacy_basepath: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls7/'
-      nbar_suffix: '/output/nbar/'
-      nbart_suffix: '/output/nbart/'
-      pq_suffix: '/output/pqa/'
-      pq_legacy_suffix: '/output/pqa/'
     events:
       - schedule:
           rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
@@ -102,88 +91,180 @@ functions:
           input:
             product: ls8_nbar_scene
             trasharchived: no
-            year: 1234  # Actual year shall be updated within lambda function handler
-            path: ""  # Path shall be updated within lambda function handler
+            year: '2016-2019'
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/'
+            suffixpath: '/??/output/nbar/'
       - schedule:
           rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
           enabled: true
           input:
             product: ls7_nbar_scene
             trasharchived: no
-            year: 1234  # Actual year shall be updated within lambda function handler
-            path: ""  # Path shall be updated within lambda function handler
+            year: '2016-2019'
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls7/'
+            suffixpath: '/??/output/nbar/'
       - schedule:
           rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
           enabled: true
           input:
             product: ls8_nbart_scene
             trasharchived: no
-            year: 1234  # Actual year shall be updated within lambda function handler
-            path: ""  # Path shall be updated within lambda function handler
+            year: '2016-2019'
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/'
+            suffixpath: '/??/output/nbart/'
       - schedule:
           rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
           enabled: true
           input:
             product: ls7_nbart_scene
             trasharchived: no
-            year: 1234  # Actual year shall be updated within lambda function handler
-            path: ""  # Path shall be updated within lambda function handler
+            year: '2016-2019'
+            path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls7/'
+            suffixpath: '/??/output/nbart/'
       - schedule:
           rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
           enabled: true
           input:
             product: ls8_pq_scene
             trasharchived: no
-            year: 1234  # Actual year shall be updated within lambda function handler
-            path: ""  # Path shall be updated within lambda function handler
+            year: '2016-2019'
+            path: '/g/data/rs0/scenes/pq-scenes-tmp/ls8/'
+            suffixpath: '/??/output/pqa/'
       - schedule:
           rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
           enabled: true
           input:
             product: ls7_pq_scene
             trasharchived: no
-            year: 1234  # Actual year shall be updated within lambda function handler
-            path: ""  # Path shall be updated within lambda function handler
+            year: '2016-2019'
+            path: '/g/data/rs0/scenes/pq-scenes-tmp/ls7/'
+            suffixpath: '/??/output/pqa/'
       - schedule:
           rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
           enabled: true
           input:
             product: ls8_pq_legacy_scene
             trasharchived: no
-            year: 1234  # Actual year shall be updated within lambda function handler
-            path: ""  # Path shall be updated within lambda function handler
+            year: '2016-2019'
+            path: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls8/'
+            suffixpath: '/??/output/pqa/'
       - schedule:
           rate: cron(10 10 ? * FRI *)  # Run every Friday, at 08:10 pm Canberra time
           enabled: true
           input:
             product: ls7_pq_legacy_scene
             trasharchived: no
-            year: 1234  # Actual year shall be updated within lambda function handler
-            path: ""  # Path shall be updated within lambda function handler
-  execute_s2ard_sync:
-    # trasharchived is set to 'yes' only for the albers products and not for the scenes
-    handler: handler.execute_ssh_command
-    description: Sync Sentinal 2 ARD Granules
-    environment:
-      cmd: 'execute_sync --dea-module ${self:provider.environment.DEA_MODULE}
-                         --queue ${self:provider.environment.QUEUE}
-                         --project ${self:provider.environment.PROJECT}
-                         --stage ${self:custom.Stage}
-                         --year <%= year %>
-                         --path <%= path %>
-                         --product <%= product %>
-                         --trasharchived <%= trasharchived %>'
-      basepath: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
-      yearrange: '2015-2019'
-    events:
+            year: '2016-2019'
+            path: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls7/'
+            suffixpath: '/??/output/pqa/'
       - schedule:
           rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
           enabled: true
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: 2019  # Actual year shall be updated within lambda function handler
-            path: ""  # Path shall be updated within lambda function handler
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-01-*/*/'  # Process January month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-02-*/*/'  # Process February month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-03-*/*/'  # Process March month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-04-*/*/'  # Process April month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-05-*/*/'  # Process May month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-06-*/*/'  # Process June month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-07-*/*/'  # Process July month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-08-*/*/'  # Process August month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-09-*/*/'  # Process September month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-10-*/*/'  # Process October month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-11-*/*/'  # Process November month data
+      - schedule:
+          rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
+          enabled: true
+          input:
+            product: s2_ard_granule
+            trasharchived: no
+            year: '2015-2019'
+            path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
+            suffixpath: '-12-*/*/'  # Process December month data
   execute_ingest:
     handler: handler.execute_ssh_command
     description: Execute dea-submit-ingest qsub tool to ingest datasets to the database
@@ -396,12 +477,11 @@ functions:
                                    --project ${self:provider.environment.PROJECT}
                                    --cog-product <%= cog_product %>
                                    --time-range <%= time_range %>'
-      # Max configurable years is 8 years due to lambda function timeout limitation
-      yearrange: '2017-2018'
     events:
       - schedule:
           rate: cron(30 10 ? * TUE *)  # Run every Tuesday, at 08:30 pm Canberra time
           enabled: false
           input:
             cog_product: wofs_albers
-            time_range: ""  # time range shall be updated within lambda function handler
+            # Max configurable years is 8 years due to lambda function timeout limitation
+            time_range: '2017-2018'

--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -330,14 +330,14 @@ functions:
           input:
             year: 2019
             product: ls8_fc_albers
-            tag: 'ls8_fc2018'
+            tag: 'ls8_fc2019'
       - schedule:
           rate: cron(15 10 ? * SUN *)  # Run every Sunday, at 08:15 pm Canberra time
           enabled: true
           input:
             year: 2019
             product: ls7_fc_albers
-            tag: 'ls7_fc2018'
+            tag: 'ls7_fc2019'
   execute_wofs:
     handler: handler.execute_ssh_command
     description: Execute datacube-wofs submit tool to generate wofs and ingest them to the database
@@ -479,9 +479,9 @@ functions:
                                    --time-range <%= time_range %>'
     events:
       - schedule:
-          rate: cron(30 10 ? * TUE *)  # Run every Tuesday, at 08:30 pm Canberra time
+          rate: cron(30 10 ? * MON *)  # Run every Monday, at 08:30 pm Canberra time
           enabled: false
           input:
             cog_product: wofs_albers
             # Max configurable years is 8 years due to lambda function timeout limitation
-            time_range: '2017-2018'
+            time_range: '2017-2019'

--- a/lambda_functions/simple_s3_pypi/genindex.py
+++ b/lambda_functions/simple_s3_pypi/genindex.py
@@ -34,7 +34,7 @@ def generate_listing(event, context):
 
 
 def process_directory(bucket, directory):
-    LOG.info(f"Processing s3://%s/%s", bucket, directory)
+    LOG.info(f"Processing s3://{bucket}/{directory}")
     s3client = boto3.client('s3')
     response = s3client.list_objects_v2(Bucket=bucket, Prefix=f"{directory}/", Delimiter='/')
 
@@ -42,7 +42,7 @@ def process_directory(bucket, directory):
     folders = [prefix['Prefix'] for prefix in response.get('CommonPrefixes', [])]
 
     index_path = path.join(directory, 'index.html')
-    LOG.info(f"Found '%s' in '%s'. Updating '%s'.", len(files), directory, index_path)
+    LOG.info(f"Found '{len(files)}' in '{directory}'. Updating '{index_path}'.")
 
     index_contents = generate_index_html(files)
     s3client.put_object(Bucket=bucket, Key=index_path, Body=index_contents, ContentType="text/html",

--- a/lambda_functions/simple_s3_pypi/genindex.py
+++ b/lambda_functions/simple_s3_pypi/genindex.py
@@ -34,7 +34,7 @@ def generate_listing(event, context):
 
 
 def process_directory(bucket, directory):
-    LOG.info(f"Processing s3://{bucket}/{directory}")
+    LOG.info("Processing s3://%s/%s", bucket, directory)
     s3client = boto3.client('s3')
     response = s3client.list_objects_v2(Bucket=bucket, Prefix=f"{directory}/", Delimiter='/')
 
@@ -42,7 +42,7 @@ def process_directory(bucket, directory):
     folders = [prefix['Prefix'] for prefix in response.get('CommonPrefixes', [])]
 
     index_path = path.join(directory, 'index.html')
-    LOG.info(f"Found '{len(files)}' in '{directory}'. Updating '{index_path}'.")
+    LOG.info("Found '%s' in '%s'. Updating '%s'.", len(files), directory, index_path)
 
     index_contents = generate_index_html(files)
     s3client.put_object(Bucket=bucket, Key=index_path, Body=index_contents, ContentType="text/html",

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -283,7 +283,7 @@ def install_pip_packages(pip_conf, variables):
     else:  # Either no target or prefix OR target and prefix were in the conf
         raise Exception('Either prefix: <prefix path> or target: <target path> is required by install_pip_packages:')
 
-    LOG.info(f'Installing pip packages from [ %s ] into directory [ %s ]', requirements, dest)
+    LOG.info(f'Installing pip packages from [ {requirements} ] into directory [ {dest} ]')
     run_command(f'{pip} install -v --no-deps {arg} --compile --requirement {requirements}')
 
 
@@ -397,7 +397,7 @@ def main(config_path):
 
         LOG.info('')
         LOG.info('*'*80)
-        LOG.info(f'Run regression testing on new DEA Module (%r) ', dea_module)
+        LOG.info(f'Run regression testing on new DEA Module ({dea_module})')
         LOG.info('*'*80)
         run_command(f'sh {script_dir}/{test_script} --deamodule {dea_module} --testdir {script_dir}')
     else:

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -283,7 +283,7 @@ def install_pip_packages(pip_conf, variables):
     else:  # Either no target or prefix OR target and prefix were in the conf
         raise Exception('Either prefix: <prefix path> or target: <target path> is required by install_pip_packages:')
 
-    LOG.info(f'Installing pip packages from [ {requirements} ] into directory [ {dest} ]')
+    LOG.info('Installing pip packages from [ %s ] into directory [ %s ]', requirements, dest)
     run_command(f'{pip} install -v --no-deps {arg} --compile --requirement {requirements}')
 
 
@@ -397,7 +397,7 @@ def main(config_path):
 
         LOG.info('')
         LOG.info('*'*80)
-        LOG.info(f'Run regression testing on new DEA Module ({dea_module})')
+        LOG.info('Run regression testing on new DEA Module (%s) ', dea_module)
         LOG.info('*'*80)
         run_command(f'sh {script_dir}/{test_script} --deamodule {dea_module} --testdir {script_dir}')
     else:

--- a/raijin_scripts/execute_cog_conversion/run
+++ b/raijin_scripts/execute_cog_conversion/run
@@ -28,36 +28,50 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-WORKDIR=/g/data/v10/work/cog_conversion/"$PRODUCT"
-SUBMISSION_LOG="$WORKDIR"/Cog_Submission_$(date '+%F_%H_%m_%s').log
+WORKDIR=/g/data/v10/work/cog_conversion/"$PRODUCT"/$(date '+%F_%T')
+SUBMISSION_LOG="$WORKDIR"/Cog_Submission_$(date '+%s').log
+START_YEAR=$(echo "$RANGE_EXP" | cut -f 1 -d '-')
+END_YEAR=$(echo "$RANGE_EXP" | cut -f 2 -d '-')
+TIME_RANGE_TO_PROCESS=()
 
 mkdir -p "${WORKDIR}"
-echo "Start time: " "$(date '+%F-%T')" > "$SUBMISSION_LOG"
 
 module use /g/data/v10/public/modules/modulefiles
 module load "${MODULE}"
 
-cd "${WORKDIR}"
+for (( year = "$START_YEAR"; year <= "$END_YEAR"; ++year )); do
+    for (( month = 01; month <= 12; ++month )); do
+        TIME_RANGE_TO_PROCESS+=("'time in $year-$month'")
+    done
+done
 
-nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 << EOF &
-echo "Logging into: ${SUBMISSION_LOG}"
-echo ""
-echo Loading module ${MODULE}
-echo ""
+echo "Start time: $(date '+%F-%T')
+
+Loading module ${MODULE}
 
 # Check if we can connect to the database
-datacube -vv system check
+$(datacube -vv system check)
+" > "$SUBMISSION_LOG"
+
+cd "${WORKDIR}"
 
 echo ""
 echo "Starting Cog-Conversion process......"
 
-##################################################################################################
-# Qsub cog-convert process
-##################################################################################################
-echo "Executing: python3 $HOME/COG-Conversion/converter/cog_conv_app.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT}
--p ${PRODUCT} --walltime 20 --output-dir ${WORKDIR} --time-range '${RANGE_EXP}'"
+j=0
+for timeperiod in "${TIME_RANGE_TO_PROCESS[@]}"
+do
+  j=$((j+1))
+  nohup "$SHELL" >> "$SUBMISSION_LOG" 2>&1 << EOF &
+  ##################################################################################################
+  # Qsub cog-convert process
+  ##################################################################################################
+  mkdir -p "${WORKDIR}/cache_$j"
+  echo ""
+  echo "Executing: python3 $HOME/COG-Conversion/converter/cog_conv_app.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT}
+  -p ${PRODUCT} --walltime 20 --output-dir ${WORKDIR}/cache_$j --time-range ${timeperiod}"
 
-python3 "$HOME"/COG-Conversion/converter/cog_conv_app.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT} -p ${PRODUCT} \
---walltime 20 --output-dir ${WORKDIR} --time-range ${RANGE_EXP}
-
+  python3 "$HOME"/COG-Conversion/converter/cog_conv_app.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT} -p ${PRODUCT} \
+  --walltime 20 --output-dir ${WORKDIR}/cache_$j --time-range ${timeperiod}
 EOF
+done

--- a/raijin_scripts/execute_cog_conversion/run
+++ b/raijin_scripts/execute_cog_conversion/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -eu
-
+HOME_PATH=/g/data/u46/users/sm9911/temp_repo
 while [[ "$#" -gt 0 ]]; do
     key="$1"
     case "${key}" in
@@ -28,22 +28,17 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-WORKDIR=/g/data/v10/work/cog_conversion/"$PRODUCT"/$(date '+%F_%T')
+WORKDIR=/g/data/v10/work/cog_conversion/"$PRODUCT"/$(date '+%F_%H-%M-%S')
 SUBMISSION_LOG="$WORKDIR"/Cog_Submission_$(date '+%s').log
 START_YEAR=$(echo "$RANGE_EXP" | cut -f 1 -d '-')
 END_YEAR=$(echo "$RANGE_EXP" | cut -f 2 -d '-')
-TIME_RANGE_TO_PROCESS=()
 
 mkdir -p "${WORKDIR}"
 
 module use /g/data/v10/public/modules/modulefiles
 module load "${MODULE}"
 
-for (( year = "$START_YEAR"; year <= "$END_YEAR"; ++year )); do
-    for (( month = 01; month <= 12; ++month )); do
-        TIME_RANGE_TO_PROCESS+=("'time in $year-$month'")
-    done
-done
+TIME_RANGE_TO_PROCESS="'$START_YEAR < time < $END_YEAR'"
 
 echo "Start time: $(date '+%F-%T')
 
@@ -56,22 +51,16 @@ $(datacube -vv system check)
 cd "${WORKDIR}"
 
 echo ""
-echo "Starting Cog-Conversion process......"
+echo "Starting Cog-Conversion process for the period ${TIME_RANGE_TO_PROCESS}......"
 
-j=0
-for timeperiod in "${TIME_RANGE_TO_PROCESS[@]}"
-do
-  j=$((j+1))
-  nohup "$SHELL" >> "$SUBMISSION_LOG" 2>&1 << EOF &
-  ##################################################################################################
-  # Qsub cog-convert process
-  ##################################################################################################
-  mkdir -p "${WORKDIR}/cache_$j"
-  echo ""
-  echo "Executing: python3 $HOME/COG-Conversion/converter/cog_conv_app.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT}
-  -p ${PRODUCT} --walltime 20 --output-dir ${WORKDIR}/cache_$j --time-range ${timeperiod}"
+nohup "$SHELL" >> "$SUBMISSION_LOG" 2>&1 << EOF &
+##################################################################################################
+# Qsub cog-convert process
+##################################################################################################
+echo ""
+echo "Executing: python3 $HOME_PATH/COG-Conversion/converter/cog_conv_app.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT}
+-p ${PRODUCT} --walltime 20 --output-dir ${WORKDIR} --time-range ${TIME_RANGE_TO_PROCESS}"
 
-  python3 "$HOME"/COG-Conversion/converter/cog_conv_app.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT} -p ${PRODUCT} \
-  --walltime 20 --output-dir ${WORKDIR}/cache_$j --time-range ${timeperiod}
+python3 "$HOME_PATH"/COG-Conversion/converter/cog_conv_app.py qsub-cog-convert -q ${QUEUE} -P ${PROJECT} -p ${PRODUCT} \
+--walltime 20 --output-dir ${WORKDIR} --time-range ${TIME_RANGE_TO_PROCESS}
 EOF
-done

--- a/raijin_scripts/execute_sync/run
+++ b/raijin_scripts/execute_sync/run
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2154
 set -eu
 
 while [[ "$#" -gt 0 ]]; do
@@ -7,23 +8,20 @@ while [[ "$#" -gt 0 ]]; do
         --dea-module )          shift
                                 MODULE="$1"
                                 ;;
-        --year )                shift
-                                YEAR="$1"
-                                ;;
         --queue )               shift
                                 QUEUE="$1"
                                 ;;
         --project )             shift
                                 PROJECT="$1"
                                 ;;
-        --stage )               shift
-                                STAGE="$1"
+        --year )                shift
+                                YEAR="$1"
                                 ;;
         --path )                shift
-                                # Expand a shell glob pattern, for more flexible path definition
-                                # See https://stackoverflow.com/a/45933949/119603 for more info
-                                # shellcheck disable=SC2206
-                                PATHS_TO_PROCESS=("$1")
+                                BASE_PATH="$1"
+                                ;;
+        --suffixpath )          shift
+                                SUFFIX_PATH="$1"
                                 ;;
         --product )             shift
                                 PRODUCT="$1"
@@ -39,83 +37,59 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+PATHS_TO_PROCESS=()
+WORKDIR=/g/data/v10/work/sync/"${PRODUCT}"/$(date '+%FT%H%M')
+SYNC_CACHE="${WORKDIR}"/cache_$(date '+%N')
+SUBMISSION_LOG="$WORKDIR"/sync-submission-"${PRODUCT}"-$(date '+%F-%T').log
+JOB_NAME="${YEAR}_${PRODUCT}"
+START_YEAR=$(echo "$YEAR" | cut -f 1 -d '-')
+END_YEAR=$(echo "$YEAR" | cut -f 2 -d '-')
+
 # Override echo command to prepend timestamp before echo message
 echo() {
     command echo "$(date '+%F_%T.%N')" "$@"
 }
 
-WORKDIR=/g/data/v10/work/sync/"${PRODUCT}"/$(date '+%FT%H%M')
-SYNC_CACHE="${WORKDIR}"/cache/
-SUBMISSION_LOG="$WORKDIR"/sync-submission-"${PRODUCT}"-$(date '+%F-%T').log
-JOB_NAME="${YEAR}_${PRODUCT}"
-count=0
-dbhostname='agdcdev-db.nci.org.au'
-dbport='6432'
-dbname='datacube'
-
 mkdir -p "${SYNC_CACHE}"
-echo "Start time: " "$(date '+%F-%T')" > "$SUBMISSION_LOG"
 
 module use /g/data/v10/public/modules/modulefiles
 module load "${MODULE}"
-while read -r LINE; do
-  if [[ "$count" -eq 1 ]]
-  then
-      dbhostname="$(cut -d' ' -f2 <<<"$LINE")"
-      count="$((count+1))"
-  elif [[ "$count" -eq 2 ]]
-  then
-      dbport="$(cut -d' ' -f2 <<<"$LINE")"
-      count="$((count+1))"
-  elif [[ "$count" -eq 3 ]]
-  then
-      dbname="$(cut -d' ' -f2 <<<"$LINE")"
-      count="$((count+1))"
-  fi
-
-  if [[ "${STAGE}" == "dev"  && "$LINE" == "[dea-dev]" ]]; then
-      count="$((count+1))"
-  fi
-
-  if [[ "${STAGE}" == "prod"  && "$LINE" == "[datacube]" ]]; then
-      count="$((count+1))"
-  fi
-done  < "$DATACUBE_CONFIG_PATH"
 
 TRASH_ARCHIVED=''
 if [ "$TRASH_ARC" == yes ]; then
    TRASH_ARCHIVED='--trash-archived'
 fi
 
+for (( year = "$START_YEAR"; year <= "$END_YEAR"; ++year )); do
+    PATHS_TO_PROCESS+=("$BASE_PATH$year$SUFFIX_PATH")
+done
+
 cd "${WORKDIR}"
 
-nohup "$SHELL" > "$SUBMISSION_LOG" 2>&1 << EOF &
-echo "Logging job: ${JOB_NAME} into: ${SUBMISSION_LOG}"
-echo ""
-echo Loading module "${MODULE}"
-echo ""
+echo "Start time: $(date '+%F-%T')
+
+Logging job: ${JOB_NAME} into: ${SUBMISSION_LOG}
+Loading module ${MODULE}
 
 # Check if we can connect to the database
-datacube -vv system check
+$(datacube -vv system check)
+" > "$SUBMISSION_LOG"
 
-# Read agdc datasets from the database before sync process
-echo ""
-echo "**********************************************************************"
-echo "Read previous agdc_dataset product names and count before sync process"
-echo "Connected to the database host name: ${dbhostname}"
-echo "Connected to the database port number: ${dbport}"
-echo "Connected to the database name: ${dbname}"
-psql -h ${dbhostname} -p ${dbport} -d ${dbname} \
-  -c 'select name, count(*) FROM agdc.dataset a, agdc.dataset_type b where a.dataset_type_ref = b.id group by b.name'
-echo "**********************************************************************"
+for syncpath in "${PATHS_TO_PROCESS[@]}"
+do
+  nohup "$SHELL" >> "$SUBMISSION_LOG" 2>&1 << EOF &
+  ##################################################################################################
+  # Run dea-sync process
+  ##################################################################################################
+  echo ""
+  echo "qsub -V -N dea-sync -q ${QUEUE} -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=16 -m ae \
+  -M nci.monitor@dea.ga.gov.au -P ${PROJECT} -o ${WORKDIR} -e ${WORKDIR} \
+  -- dea-sync -vvv --cache-folder ${SYNC_CACHE} -j 4 --log-queries ${TRASH_ARCHIVED} --update-locations \
+  --index-missing ${syncpath}"
 
-echo ""
-echo "Starting Sync process......"
-##################################################################################################
-# Run dea-sync process
-##################################################################################################
-qsub -V -N dea-sync -q ${QUEUE} -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=1 -m ae \
-   -M nci.monitor@dea.ga.gov.au -P "${PROJECT}" -o ${WORKDIR} -e ${WORKDIR} \
-   -- dea-sync -vvv --cache-folder ${WORKDIR}/cache -j 4 --log-queries ${TRASH_ARCHIVED} --update-locations \
-   --index-missing ${PATHS_TO_PROCESS[@]}
+  qsub -V -N dea-sync -q ${QUEUE} -W umask=33 -l wd,walltime=10:00:00,mem=25GB,ncpus=16 -m ae \
+  -M nci.monitor@dea.ga.gov.au -P "${PROJECT}" -o ${WORKDIR} -e ${WORKDIR} \
+  -- dea-sync -vvv --cache-folder "${SYNC_CACHE}" -j 4 --log-queries ${TRASH_ARCHIVED} --update-locations \
+  --index-missing "${syncpath}"
 EOF
+done


### PR DESCRIPTION
# Request for this pull request
Lambda function had too many product specific processing code. This will make it hard to maintain, when we have more new products added to the orchestration configuration.

# Proposed solution
- Simplify lambda function within `lambda_functions/execute_ssh_command_js/handler.js` file by moving product specific processing into serverless configuration file.
- Update `lambda_functions/execute_ssh_command_js/serverless.yml` configuration file to manage product specific setting.
- Update `raijin_scripts/execute_cog_conversion/run` file to format `time` `query` and process entire time range as a single `qsub` command. 
- Update `raijin_scripts/execute_sync/run` file to submit `qsub` jobs broken down to individual year as per the configuration setting (`year`).
- Fix `fstring` interpolation failures in `lambda_functions/simple_s3_pypi/genindex.py` file and `raijin_scripts/deploy/build_environment_module.py` file.