### PR TITLE
Added version parameter to execute script; re-enabling s2

### DIFF
--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -448,7 +448,7 @@ functions:
             obs_year: previous
       - schedule:
           rate: cron(5 1 ? * SAT *) # Run every Saturday at 11:05 AM, AEST
-          enabled: false
+          enabled: true
           input:
             task: level2
             start_date_offset: 12 # Process from Monday 00:00 to Monday 00:00
@@ -459,7 +459,7 @@ functions:
             obs_year: current
       - schedule:
           rate: cron(5 5 5 * ? *) # Run monthly on the 5th, kick off find command at 3:05pm
-          enabled: false
+          enabled: true
           input:
             task: level2
             start_date_offset: 35 # Kicks off re-processing for the past month for previous years on the 5th

--- a/raijin_scripts/execute_s2ard/run
+++ b/raijin_scripts/execute_s2ard/run
@@ -7,6 +7,7 @@ set -eu
 
 FILE_MOD_END=""
 FILE_MOD_START_OFFSET=""
+WAGL_VERSION='5.3.1'
 
 # OBS_YEAR is the observation year to process
 OBS_YEAR=""
@@ -101,7 +102,7 @@ echo "Loading module wagl module"
 module use /g/data/v10/public/modules/modulefiles
 module use /g/data/v10/private/modules/modulefiles
 
-module load wagl/5.3.0
+module load "wagl/${WAGL_VERSION}"
 
 
 # Queue each year individually to reduce real time and total memory
@@ -137,7 +138,7 @@ for (( _year="${_OBS_YEAR_START}"; _year<="$_OBS_YEAR_END"; _year++ )); do
                         --workdir "$WAGL_WORKDIR" \
                         --start-date "$FILE_MOD_START" \
                         --end-date "$FILE_MOD_END" \
-                        --env "${WAGL_CFG_ROOT}/5.3.0/Sentinel-2/definitive.env" \
+                        --env "${WAGL_CFG_ROOT}/${WAGL_VERSION}/Sentinel-2/definitive.env" \
                         --project "$PROJECT"
                     ;;
          "*"        )


### PR DESCRIPTION
* Re-enables sentinel-2 processing with a version increment
* Version increment includes configuration to include averaged water vapour datasets as a fallback option