### PR TITLE
Refactored valid data projection code for STAC lambdas

### DIFF
--- a/lambda_functions/stac/requirements.txt
+++ b/lambda_functions/stac/requirements.txt
@@ -3,3 +3,4 @@ pyproj==1.9.5.1
 parse==1.9.0
 python_dateutil==2.7.5
 PyYAML==3.13
+pycrs==1.0.0

--- a/lambda_functions/stac/stac_check.py
+++ b/lambda_functions/stac/stac_check.py
@@ -179,7 +179,7 @@ def test_stac_items(s3_dataset_yamls, upload_yamls_from_prod_to_dev):
 
     # We may need to wait here a bit until messages in the queue are delivered
     # This should be at least timeout of lambda
-    time.sleep(300)
+    time.sleep(500)
 
     s3_client = boto3.client('s3')
     for dts in s3_dataset_yamls:


### PR DESCRIPTION
Some products store the `CRS` string in `ESRI/OGC WKT` format rather than as an
`EPSG` code. `Data cube CRS` or `Geometry` classes are hard to use in AWS
Lambdas due to the large size of `GDAL` or `rasterio`. Together with other
dependencies, they exceed the 50MB size limit of AWS Lambdas files). 

Instead, we can use the pure python `pycrs` library to parse `crs strings` to `proj4` format.