### PR TITLE
Patch dea env

### DIFF
--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -25,8 +25,8 @@ dependencies:
 - cvxopt
 - cvxpy
 - cython
-- dask
-- distributed
+- dask == 0.19.3  # Datacube ingest app has an issue (datacube-core issue #658), with version later than this
+- distributed == 1.23.3  # Datacube ingest app has an issue (datacube-core issue #658), with version later than this
 - docutils
 - ephem
 - expat
@@ -120,7 +120,7 @@ dependencies:
 - rasterstats
 - recommonmark
 - redis
-- redis-py
+- redis-py == 2.10.6  # FC, wofs, and datacube-stats app has an issue (digitalearthau issue #205), with later revisions
 - rios
 - rtree
 - s3transfer
@@ -138,7 +138,7 @@ dependencies:
 - spyder
 - sqlalchemy
 - sqlite
-- tensorflow == 1.9.0
+- tensorflow == 1.9.0  # https://github.com/conda-forge/tensorflow-feedstock/issues/11
 - tornado
 - tqdm
 - tuiview

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -138,7 +138,7 @@ dependencies:
 - spyder
 - sqlalchemy
 - sqlite
-- tensorflow == 1.9.0  # https://github.com/conda-forge/tensorflow-feedstock/issues/11
+- tensorflow == 1.9.0  # Import issue workaround, https://github.com/conda-forge/tensorflow-feedstock/issues/11
 - tornado
 - tqdm
 - tuiview


### PR DESCRIPTION
# Reason for this pull request
`Datacube` `ingest`, `datacube-fc`, `datacube-wofs`, and `datacube-stats` apps had issues with latest revision of `dask`, `distributed`, and `redis-py` `python` `conda` packages. 

# Proposed solutions
Revert `dask`, `distributed`, and `redis-py` `conda` packages to last know working revisions.

- Workaround for [[https://github.com/GeoscienceAustralia/digitalearthau/issues/205](url)] and [[https://github.com/opendatacube/datacube-core/issues/658](url)]