### PR TITLE
Fix s2ard sync issue

### DIFF
--- a/lambda_functions/execute_ssh_command_js/serverless.yml
+++ b/lambda_functions/execute_ssh_command_js/serverless.yml
@@ -91,7 +91,7 @@ functions:
           input:
             product: ls8_nbar_scene
             trasharchived: no
-            year: '2016-2019'
+            year: '2019-2019'
             path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/'
             suffixpath: '/??/output/nbar/'
       - schedule:
@@ -100,7 +100,7 @@ functions:
           input:
             product: ls7_nbar_scene
             trasharchived: no
-            year: '2016-2019'
+            year: '2019-2019'
             path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls7/'
             suffixpath: '/??/output/nbar/'
       - schedule:
@@ -109,7 +109,7 @@ functions:
           input:
             product: ls8_nbart_scene
             trasharchived: no
-            year: '2016-2019'
+            year: '2019-2019'
             path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls8/'
             suffixpath: '/??/output/nbart/'
       - schedule:
@@ -118,7 +118,7 @@ functions:
           input:
             product: ls7_nbart_scene
             trasharchived: no
-            year: '2016-2019'
+            year: '2019-2019'
             path: '/g/data/rs0/scenes/nbar-scenes-tmp/ls7/'
             suffixpath: '/??/output/nbart/'
       - schedule:
@@ -127,7 +127,7 @@ functions:
           input:
             product: ls8_pq_scene
             trasharchived: no
-            year: '2016-2019'
+            year: '2019-2019'
             path: '/g/data/rs0/scenes/pq-scenes-tmp/ls8/'
             suffixpath: '/??/output/pqa/'
       - schedule:
@@ -136,7 +136,7 @@ functions:
           input:
             product: ls7_pq_scene
             trasharchived: no
-            year: '2016-2019'
+            year: '2019-2019'
             path: '/g/data/rs0/scenes/pq-scenes-tmp/ls7/'
             suffixpath: '/??/output/pqa/'
       - schedule:
@@ -145,7 +145,7 @@ functions:
           input:
             product: ls8_pq_legacy_scene
             trasharchived: no
-            year: '2016-2019'
+            year: '2019-2019'
             path: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls8/'
             suffixpath: '/??/output/pqa/'
       - schedule:
@@ -154,34 +154,34 @@ functions:
           input:
             product: ls7_pq_legacy_scene
             trasharchived: no
-            year: '2016-2019'
+            year: '2019-2019'
             path: '/g/data/rs0/scenes/pq-legacy-scenes-tmp/ls7/'
             suffixpath: '/??/output/pqa/'
       - schedule:
           rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
-          enabled: false
+          enabled: true
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-01-'  # Process January month data
       - schedule:
           rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
-          enabled: false
+          enabled: true
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-02-'  # Process February month data
       - schedule:
           rate: cron(10 10 ? * THU *)  # Run every Thursday, at 08:10 pm Canberra time
-          enabled: false
+          enabled: true
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-03-'  # Process March month data
       - schedule:
@@ -190,7 +190,7 @@ functions:
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-04-'  # Process April month data
       - schedule:
@@ -199,7 +199,7 @@ functions:
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-05-'  # Process May month data
       - schedule:
@@ -208,7 +208,7 @@ functions:
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-06-'  # Process June month data
       - schedule:
@@ -217,7 +217,7 @@ functions:
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-07-'  # Process July month data
       - schedule:
@@ -226,7 +226,7 @@ functions:
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-08-'  # Process August month data
       - schedule:
@@ -235,7 +235,7 @@ functions:
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-09-'  # Process September month data
       - schedule:
@@ -244,7 +244,7 @@ functions:
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-10-'  # Process October month data
       - schedule:
@@ -253,7 +253,7 @@ functions:
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-11-'  # Process November month data
       - schedule:
@@ -262,7 +262,7 @@ functions:
           input:
             product: s2_ard_granule
             trasharchived: no
-            year: '2018-2019'
+            year: '2019-2019'
             path: '/g/data/if87/datacube/002/S2_MSI_ARD/packaged/'
             suffixpath: '-12-'  # Process December month data
   execute_ingest:
@@ -370,7 +370,7 @@ functions:
     events:
       - schedule:
           rate: cron(00 09 ? * TUE *)  # Run every Tuesday, at 07:00 pm Canberra time
-          enabled: true
+          enabled: false
           input:
             timequery: 'time in 2019'
             product: all
@@ -387,7 +387,7 @@ functions:
     events:
       - schedule:
           rate: cron(00 12 ? * * *)  # Run every day, at 10:00 pm Canberra time
-          enabled: true
+          enabled: false
           input:
             awsprofile: default
             recemail: nci.monitor@dea.ga.gov.au  # Recepient's email address
@@ -404,7 +404,7 @@ functions:
     events:
       - schedule:
           rate: cron(00 13 ? * TUE *)  # Run every Tuesday, at 11:00 pm Canberra time
-          enabled: true
+          enabled: false
           input:
             min_trash_age: 72  # 72 hours
             search_paths: /g/data/rs0/datacube/002/
@@ -483,4 +483,4 @@ functions:
           enabled: true
           input:
             cog_product: wofs_albers
-            time_range: '2010-2019'
+            time_range: '2019-2019'

--- a/raijin_scripts/deploy/dea/datacube-ensure-user.py
+++ b/raijin_scripts/deploy/dea/datacube-ensure-user.py
@@ -75,19 +75,19 @@ def find_credentials(pgpass, host, dbcreds):
     if not pgpass.exists() or os.path.getsize(pgpass) == 0:
         # New user, add new credentials to connect to any database
         raise CredentialsNotFound("New user: Add new credentials to .pgpass file")
-    else:
-        with pgpass.open() as src:
-            for line in src:
-                # Ignore comments and empty lines
-                if not line.strip().startswith('#') and line.strip():
-                    creds = DBCreds(*line.strip().split(':'))
-                    if creds.host == host and creds.username == dbcreds.username:
-                        # Production database credentials exists
-                        new_creds = creds._replace(host="*", port="*")
-                    elif creds.host == "*" and creds.username == dbcreds.username:
-                        # Already migrated to new database format, do noting
-                        new_creds = None
-        return new_creds
+
+    with pgpass.open() as src:
+        for line in src:
+            # Ignore comments and empty lines
+            if not line.strip().startswith('#') and line.strip():
+                creds = DBCreds(*line.strip().split(':'))
+                if creds.host == host and creds.username == dbcreds.username:
+                    # Production database credentials exists
+                    new_creds = creds._replace(host="*", port="*")
+                elif creds.host == "*" and creds.username == dbcreds.username:
+                    # Already migrated to new database format, do noting
+                    new_creds = None
+    return new_creds
 
 
 def append_credentials(pgpass, dbcreds):

--- a/raijin_scripts/execute_sync/run
+++ b/raijin_scripts/execute_sync/run
@@ -92,9 +92,9 @@ do
   ##################################################################################################
   set -x  # echo is on
 
-  qsub -V -N dea-sync -q ${QUEUE} -W umask=33 -l wd,walltime=20:00:00,mem=310GB,ncpus=80 -m ae \
+  qsub -V -N dea-sync -q ${QUEUE} -W umask=33 -l wd,walltime=20:00:00,mem=3GB -m ae \
   -M nci.monitor@dea.ga.gov.au -P ${PROJECT} -o ${WORKDIR} -e ${WORKDIR} \
-  -- dea-sync -vvv --cache-folder ${SYNC_CACHE} -j 4 --log-queries ${TRASH_ARCHIVED} --update-locations \
+  -- dea-sync -vvv --cache-folder ${SYNC_CACHE} -j 1 --log-queries ${TRASH_ARCHIVED} --update-locations \
   --index-missing ${syncpath}
 
   set +x  # echo is off

--- a/raijin_scripts/execute_sync/run
+++ b/raijin_scripts/execute_sync/run
@@ -60,8 +60,8 @@ fi
 for (( year = "$START_YEAR"; year <= "$END_YEAR"; ++year )); do
   if [[ "${PRODUCT}" == "s2_ard_granule" ]]
   then
-    for day in {01..31}; do
-      PATHS_TO_PROCESS+=("$BASE_PATH$year$SUFFIX_PATH$day/*/")
+    for day in {0..3}; do
+      PATHS_TO_PROCESS+=("$BASE_PATH$year$SUFFIX_PATH$day*/*/")
     done
   else
     PATHS_TO_PROCESS+=("$BASE_PATH$year$SUFFIX_PATH")
@@ -92,7 +92,7 @@ do
   ##################################################################################################
   set -x  # echo is on
 
-  qsub -V -N dea-sync -q ${QUEUE} -W umask=33 -l wd,walltime=20:00:00,mem=25GB,ncpus=16 -m ae \
+  qsub -V -N dea-sync -q ${QUEUE} -W umask=33 -l wd,walltime=20:00:00,mem=310GB,ncpus=80 -m ae \
   -M nci.monitor@dea.ga.gov.au -P ${PROJECT} -o ${WORKDIR} -e ${WORKDIR} \
   -- dea-sync -vvv --cache-folder ${SYNC_CACHE} -j 4 --log-queries ${TRASH_ARCHIVED} --update-locations \
   --index-missing ${syncpath}


### PR DESCRIPTION
# Request for pull request
`Sentinal 2` `ARD` `A/B` `sync` orchestration job pushed hundreds of jobs to the `PBS` `job` `queue`. This was causing significant delays in `qsub` job execution.
**Root cause:** `sync` path in a single `qsub` job for `s2_ard_granule` was submitted without grouping. 
     **for ex.** a single `qsub` was submitted to process datasets on a daily basis instead of grouping them.

# Proposed solution
- Group number of days and then submit sync job. This way the max number of `pbs` jobs submitted in a year for `s2_ard_granule` is reduced to `48` from `365`.
- Update orchestration year to process `2019` year.
- Fix `pylint` error.