### PR TITLE
Fix dea env issues

### DIFF
--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -370,8 +370,7 @@ def main(config_path):
     if 'install_conda_packages' in config:
         install_conda_packages(config['install_conda_packages'], variables)
 
-    if 'install_pip_packages' in config:
-        install_pip_packages(config['install_pip_packages'], variables)
+    install_pip_packages(config['install_pip_packages'], variables)
 
     copy_files(config.get('copy_files', []), variables)
     copy_and_fill_templates(config.get('template_files', []), variables)

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -17,10 +17,6 @@ New DEA-Env Module
   $ # Building a new Environment Module:
   $ ./build_environment_module.py dea-env/modulespec.yaml
 
-# https://github.com/conda-forge/tensorflow-feedstock/issues/11
-Once dea-env module is built, install tensorflow as follows:
-  $ <new dea env module path>/bin/conda install -y -c jjhelmus tensorflow
-
 New DEA Module
   $ module use /g/data/v10/public/modules/modulefiles/
   $ module load python3/3.6.2

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -106,6 +106,13 @@ def date(date_format="%Y%m%d") -> str:
     return datetime.datetime.now().strftime(date_format)
 
 
+def _log_output(line):
+    try:
+        LOG.info(line.encode('ascii').decode('utf-8'))
+    except UnicodeEncodeError:
+        LOG.warning("UnicodeEncodeError: %s", line.encode('ascii', 'replace'))
+
+
 def run_command(cmd):
     """
     Run subprocess command and print the output on the terminal and the log file
@@ -123,18 +130,10 @@ def run_command(cmd):
                                      errors='replace')
 
         for line in proc_output.stdout.split(os.linesep):
-            try:
-                log_value = line.encode('ascii').decode('utf-8')
-                LOG.info(log_value)
-            except UnicodeEncodeError:
-                LOG.warning('UnicodeEncodeError: %s ', line.encode('ascii', 'replace'))
+            _log_output(line)
     except subprocess.CalledProcessError as suberror:
         for line in suberror.stdout.split(os.linesep):
-            try:
-                log_value = line.encode('ascii').decode('utf-8')
-                LOG.error(log_value)
-            except UnicodeEncodeError:
-                LOG.warning("UnicodeEncodeError : %s", line.encode('ascii', 'replace'))
+            _log_output(line)
 
 
 def install_conda_packages(env_file, variables):

--- a/raijin_scripts/deploy/dea-env/env_requirements.txt
+++ b/raijin_scripts/deploy/dea-env/env_requirements.txt
@@ -1,0 +1,8 @@
+jinja2
+checksumdir
+click-datetime
+DAWG
+ffmpeg-python
+hdmedians
+meinheld
+pyDEM

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -4,6 +4,7 @@ channels:
 - brittainhard
 dependencies:
 - affine
+- apscheduler
 - attrs
 - basemap
 - black
@@ -37,7 +38,7 @@ dependencies:
 - future
 - freetype
 - freexl
-- gdal
+- gdal >= 2.4.0
 - geopandas
 - geopy
 - geos
@@ -95,6 +96,7 @@ dependencies:
 - numexpr
 - numpy >= 1.16
 - openjpeg
+- openmpi
 - pandas
 - parallel
 - pcre
@@ -122,6 +124,7 @@ dependencies:
 - redis
 - redis-py == 2.10.6  # FC, wofs, and datacube-stats app has an issue (digitalearthau issue #205), with later revisions
 - rios
+- rsgislib
 - rtree
 - s3transfer
 - scikit-image

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -5,21 +5,25 @@ dependencies:
 - affine
 - apscheduler
 - attrs
+- awscli
 - basemap
 - black
-- bottleneck
+- boltons
 - boto3
-- bqplot
 - botocore
+- bottleneck
+- bqplot
 - cachetools
 - cairo
 - cartopy
+- celery
+- ciso8601
 - click
 - click-plugins
 - cligj
 - cmocean
 - compliance-checker
-- conda
+- conda == 4.6.2  # https://github.com/conda/conda/issues/8404
 - conda-env
 - curl
 - cvxopt
@@ -31,13 +35,15 @@ dependencies:
 - ephem
 - expat
 - brittainhard::fancyimpute
+- flask
+- flask-caching
 - fiona
 - folium
 - fontconfig
-- future
 - freetype
 - freexl
-- gdal >= 2.4.0
+- future
+- gdal
 - geopandas
 - geopy
 - geos
@@ -45,19 +51,21 @@ dependencies:
 - gettext
 - giflib
 - glib
-- glueviz
 - glue-geospatial
+- glueviz
 - graphviz  # This is only graphviz itself, not the python bindings. The latter are in the pip section.
+- gunicorn
+- h5py
 - hdbscan
 - hdf4
 - hdf5
-- h5py
 - hypothesis
 - icu
 - intel-openmp
 - ipdb
 - ipyleaflet
 - ipympl
+- ipython-sql
 - ipywidgets
 - jmespath
 - joblib
@@ -69,8 +77,8 @@ dependencies:
 - jupyter_contrib_nbextensions
 - jupyter_dashboards
 - jupyterlab
-- keras
 - kealib
+- keras
 - krb5
 - libgdal
 - libgfortran
@@ -85,8 +93,10 @@ dependencies:
 - mkl_fft
 - mkl_random
 - mock
+- modernize
 - mpi4py
 - munch
+- mypy
 - nb_conda_kernels
 - netcdf4
 - nodejs
@@ -98,17 +108,22 @@ dependencies:
 - openmpi
 - pandas
 - parallel
+- parse
 - pcre
 - pep8
+- perf
+- pip == 19.0.1
 - pixman
 - plotly
 - poppler
 - poppler-data
 - proj4
 - psutil
-- pthread-stubs
 - psycopg2
+- pthread-stubs
+- pudb
 - py6s
+- pydash
 - pylint
 - pyparsing
 - pypeg2
@@ -141,6 +156,7 @@ dependencies:
 - spyder
 - sqlalchemy
 - sqlite
+- structlog
 - jjhelmus::tensorflow  # Import issue workaround, https://github.com/conda-forge/tensorflow-feedstock/issues/11
 - tornado
 - tqdm
@@ -152,32 +168,6 @@ dependencies:
 - xerces-c
 - xgboost
 - yaml
+- yamllint
+- yappi
 - yarn
-- pip:
-  - autopep8
-  - awscli
-  - boltons
-  - celery
-  - checksumdir
-  - ciso8601
-  - click-datetime
-  - DAWG
-  - ffmpeg-python
-  - flask
-  - Flask-Caching
-  - graphviz
-  - gunicorn
-  - hdmedians
-  - ipython-sql
-  - meinheld
-  - modernize
-  - mypy
-  - opencv-python
-  - parse
-  - perf
-  - pudb
-  - pydash
-  - pyDEM
-  - structlog[dev]
-  - yamllint
-  - yappi

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -16,14 +16,13 @@ dependencies:
 - cachetools
 - cairo
 - cartopy
-- celery
 - ciso8601
 - click
 - click-plugins
 - cligj
 - cmocean
 - compliance-checker
-- conda == 4.6.2  # https://github.com/conda/conda/issues/8404
+- conda
 - conda-env
 - curl
 - cvxopt
@@ -53,7 +52,7 @@ dependencies:
 - glib
 - glue-geospatial
 - glueviz
-- graphviz  # This is only graphviz itself, not the python bindings. The latter are in the pip section.
+- graphviz
 - gunicorn
 - h5py
 - hdbscan
@@ -112,7 +111,6 @@ dependencies:
 - pcre
 - pep8
 - perf
-- pip == 19.0.1
 - pixman
 - plotly
 - poppler
@@ -133,6 +131,7 @@ dependencies:
 - python >= 3.6.6
 - python-dateutil
 - pyyaml
+- qgis
 - rasterio >= 1.0.20
 - rasterstats
 - recommonmark
@@ -171,3 +170,12 @@ dependencies:
 - yamllint
 - yappi
 - yarn
+- pip:
+  - celery
+  - checksumdir
+  - click-datetime
+  - DAWG
+  - ffmpeg-python
+  - hdmedians
+  - meinheld
+  - pyDEM

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -1,7 +1,6 @@
 name: dea-env
 channels:
 - conda-forge
-- brittainhard
 dependencies:
 - affine
 - apscheduler
@@ -31,7 +30,7 @@ dependencies:
 - docutils
 - ephem
 - expat
-- fancyimpute
+- brittainhard::fancyimpute
 - fiona
 - folium
 - fontconfig
@@ -81,8 +80,8 @@ dependencies:
 - luigi
 - matplotlib
 - memory_profiler
-# - mkl-service
-- mkl
+- anaconda::mkl-service
+- intel::mkl
 - mkl_fft
 - mkl_random
 - mock
@@ -118,7 +117,7 @@ dependencies:
 - python >= 3.6.6
 - python-dateutil
 - pyyaml
-- rasterio >= 1.0.15
+- rasterio >= 1.0.20
 - rasterstats
 - recommonmark
 - redis
@@ -141,7 +140,7 @@ dependencies:
 - spyder
 - sqlalchemy
 - sqlite
-- tensorflow == 1.9.0  # Import issue workaround, https://github.com/conda-forge/tensorflow-feedstock/issues/11
+- jjhelmus::tensorflow  # Import issue workaround, https://github.com/conda-forge/tensorflow-feedstock/issues/11
 - tornado
 - tqdm
 - tuiview

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -111,6 +111,7 @@ dependencies:
 - py6s
 - pylint
 - pyparsing
+- pypeg2
 - pytables
 - pytest
 - pytest-cov
@@ -177,7 +178,6 @@ dependencies:
   - pudb
   - pydash
   - pyDEM
-  - pypeg2
   - structlog[dev]
   - yamllint
   - yappi

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -15,9 +15,16 @@ install_conda_packages: environment.yaml
 
 dea_env_miniconda3: reinstall_miniconda.sh
 
+install_pip_packages:
+  requirements: env_requirements.txt
+  prefix: "{module_path}"
+  pip_cmd: "{module_path}/bin/pip "
+
 copy_files:
 - src: environment.yaml
   dest: "{modules_dir}/{module_name}/{module_version}/environment.yaml"
+- src: env_requirements.txt
+  dest: "{module_path}/env_requirements.txt"
 
 template_files:
 - src: modulefile.template

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -16,15 +16,15 @@ install_conda_packages: environment.yaml
 dea_env_miniconda3: reinstall_miniconda.sh
 
 install_pip_packages:
-  requirements: env_requirements.txt
+  requirements: pip_install_packages.txt
   prefix: "{module_path}"
   pip_cmd: "{module_path}/bin/pip "
 
 copy_files:
 - src: environment.yaml
   dest: "{modules_dir}/{module_name}/{module_version}/environment.yaml"
-- src: env_requirements.txt
-  dest: "{module_path}/env_requirements.txt"
+- src: pip_install_packages.txt
+  dest: "{module_path}/pip_install_packages.txt"
 
 template_files:
 - src: modulefile.template

--- a/raijin_scripts/deploy/dea-env/pip_install_packages.txt
+++ b/raijin_scripts/deploy/dea-env/pip_install_packages.txt
@@ -1,8 +1,9 @@
-jinja2
+celery
 checksumdir
 click-datetime
 DAWG
 ffmpeg-python
 hdmedians
+jinja2
 meinheld
 pyDEM

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -11,7 +11,7 @@ cd "$TMPDIR" || exit
 "$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip
 
 # https://github.com/conda-forge/rsgislib-feedstock/issues/15
-"$MINICONDA_PATH"/bin/conda install -y -c conda-forge rsgislib
+#"$MINICONDA_PATH"/bin/conda install -y -c conda-forge rsgislib
 
 if [ ! -d "$HOME"/.nvm ]
 then

--- a/raijin_scripts/deploy/reinstall_miniconda.sh
+++ b/raijin_scripts/deploy/reinstall_miniconda.sh
@@ -8,10 +8,6 @@ chmod +x "$TMPDIR/miniconda.sh"
 cd "$TMPDIR" || exit
 ./miniconda.sh -b -f -u -p "$MINICONDA_PATH"
 "$MINICONDA_PATH"/bin/conda update -y -c conda-forge --all
-"$MINICONDA_PATH"/bin/conda install -y -c conda-forge pip
-
-# https://github.com/conda-forge/rsgislib-feedstock/issues/15
-#"$MINICONDA_PATH"/bin/conda install -y -c conda-forge rsgislib
 
 if [ ! -d "$HOME"/.nvm ]
 then

--- a/raijin_scripts/deploy/requirements.txt
+++ b/raijin_scripts/deploy/requirements.txt
@@ -1,3 +1,0 @@
-jinja2
-boto3
-pyyaml


### PR DESCRIPTION
# Reason for this pull request
`dea/20181015` require updated python `conda` packages. Also, a fix for `dea-env` build dependencies issues.

# Proposed solutions
1. `raijin_scripts/deploy/build_environment_module.py`: Refactor code and update comments within the file
2. `raijin_scripts/deploy/dea-env/environment.yaml`: To resolve issues with `dea-env` build packages, ensure packages are installed using `conda` instead of `pip`. If packages are not available within `conda` distribution packages, go with `pip` install.
3. `raijin_scripts/deploy/dea-env/environment.yaml`: Add new python conda packages: `openmpi`, `qgis`, `rsgislib`
4. `raijin_scripts/deploy/dea-env/modulespec.yaml`: Install `pip` packages during environment packaging
5. `raijin_scripts/deploy/dea-env/pip_install_packages.txt`: Add the following packages as part of pip install during `dea` environment build:
       - `celery`
       - `checksumdir`
       - `click-datetime`
       - `DAWG`
       - `ffmpeg-python`
       - `hdmedians`
       - `jinja2`
       - `meinheld`
       - `pyDEM`
6. `raijin_scripts/deploy/reinstall_miniconda.sh`: Remove `pip` and `rsgislib` `conda` `install` commands
7. `raijin_scripts/deploy/requirements.txt`: Delete `requirements.txt` file