### PR TITLE
Migrate to new database server

### DIFF
--- a/raijin_scripts/deploy/dea/datacube.conf
+++ b/raijin_scripts/deploy/dea/datacube.conf
@@ -12,3 +12,8 @@ db_database: datacube
 db_hostname: agdcdev-db.nci.org.au
 db_port: 6432
 db_database: datacube
+
+[datacube-pilot]
+db_hostname: 150.203.254.14
+db_port: 6432
+db_database: datacube


### PR DESCRIPTION
# Migrate to new NCI db server:
- Add new server config information in `datacube.conf` file as `datacube-pilot`
- Update `datacube-ensure-user.py` to create `new` `user` `db` account, if the user is not migrated to the new database server
- Add `pytest`