### PR TITLE
Install jupyter-server-proxy

### DIFF
--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -194,6 +194,7 @@ dependencies:
   - graphviz
   - hdmedians
   - jupyterlab-git
+  - jupyter-server-proxy  # port forwards, useful for dask dashboards
   - libtmux
   - meinheld
   - ptpython


### PR DESCRIPTION
Useful for accessing dask dashboard when using notebook via ssh port forward