### PR TITLE
Install dea-proto odc ui's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ script:
   # Configure serverless AWS custom profile settings.
   # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_DEFAULT_REGION are expected to be
   # configured in travis project web settings
-  - serverless config credentials --provider aws --key $aws_access_key_id --secret $aws_secret_access_key --profile prodProfile --overwrite
+  - serverless config credentials --provider aws --key $AWS_ACCESS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY --profile prodProfile --overwrite
+  - serverless config credentials --provider aws --key $AWS_ACCESS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY --profile dea-prod --overwrite
   - ./scripts/check-code.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ install:
 
 script:
   - npm install -g serverless
+  # Configure serverless AWS custom profile settings.
+  # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_DEFAULT_REGION are expected to be
+  # configured in travis project web settings
+  - serverless config credentials --provider aws --key $aws_access_key_id --secret $aws_secret_access_key --profile prodProfile --overwrite
   - ./scripts/check-code.sh
 
 after_success:
@@ -29,10 +33,6 @@ after_success:
 
 before_deploy:
   - npm --version
-  # Configure serverless AWS custom profile settings.
-  # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_DEFAULT_REGION are expected to be
-  # configured in travis project web settings
-  - serverless config credentials --provider aws --key $aws_access_key_id --secret $aws_secret_access_key --profile prodProfile --overwrite
 
 deploy:
  # Serverless deploy to production environment after merging to production branch

--- a/lambda_functions/stac/requirements.txt
+++ b/lambda_functions/stac/requirements.txt
@@ -6,4 +6,5 @@ python_dateutil==2.8.0
 pycrs==1.0.0
 
 # Only used for the parent update script, which is not currently run as a Lambda function
-git+https://github.com/opendatacube/dea-proto.git#egg=odc_apps_cloud&subdirectory=apps/cloud
+--extra-index-url https://packages.dea.gadevs.ga/
+odc-apps-cloud

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -283,6 +283,7 @@ def install_pip_packages(pip_conf, variables):
         raise Exception('Either prefix: <prefix path> or target: <target path> is required by install_pip_packages:')
 
     LOG.info('Installing pip packages from [ %s ] into directory [ %s ]', requirements, dest)
+
     # Do not warn when installing scripts outside PATH
     run_command(f'{pip} install -v --no-warn-script-location --no-deps {arg} --compile --requirement {requirements}')
 
@@ -380,12 +381,6 @@ def main(config_path):
     LOG.info('Run final commands on module')
     if 'finalise_commands' in config and config['finalise_commands']:
         run_final_commands_on_module(config['finalise_commands'], variables['module_path'])
-
-    if 'install_dea_proto_libraries' in config and config['install_dea_proto_libraries']:
-        pip = config['install_pip_packages']['pip_cmd']
-
-        for command in config['install_dea_proto_libraries']:
-            run_command(f"{pip} install '{command}'")
 
     fix_module_permissions(variables['module_path'])
 

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -283,7 +283,8 @@ def install_pip_packages(pip_conf, variables):
         raise Exception('Either prefix: <prefix path> or target: <target path> is required by install_pip_packages:')
 
     LOG.info('Installing pip packages from [ %s ] into directory [ %s ]', requirements, dest)
-    run_command(f'{pip} install -v --no-deps {arg} --compile --requirement {requirements}')
+    # Do not warn when installing scripts outside PATH
+    run_command(f'{pip} install -v --no-warn-script-location --no-deps {arg} --compile --requirement {requirements}')
 
 
 def find_default_version(module_name):
@@ -379,6 +380,12 @@ def main(config_path):
     LOG.info('Run final commands on module')
     if 'finalise_commands' in config and config['finalise_commands']:
         run_final_commands_on_module(config['finalise_commands'], variables['module_path'])
+
+    if 'install_dea_proto_libraries' in config and config['install_dea_proto_libraries']:
+        pip = config['install_pip_packages']['pip_cmd']
+
+        for command in config['install_dea_proto_libraries']:
+            run_command(f"{pip} install '{command}'")
 
     fix_module_permissions(variables['module_path'])
 

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -15,10 +15,12 @@ dependencies:
 - cachetools
 - cairo
 - cartopy
+- cffi
 - ciso8601
 - click
 - click-plugins
 - cligj
+- cmake
 - cmocean
 - compliance-checker
 - colour
@@ -60,6 +62,7 @@ dependencies:
 - hdf5
 - hypothesis
 - icu
+- importlib_resources
 - intel-openmp
 - ipdb
 - ipyleaflet
@@ -91,6 +94,7 @@ dependencies:
 - anaconda::mkl-service
 - intel::mkl
 - mkl_fft
+- anaconda::mkl-include
 - mkl_random
 - mock
 - modernize
@@ -105,7 +109,7 @@ dependencies:
 - notebook
 - numba
 - numexpr
-- numpy >= 1.16
+- numpy
 - openjpeg
 - openmpi
 - pandas
@@ -131,16 +135,16 @@ dependencies:
 - pylint
 - pyparsing
 - pypeg2
-- pysolar >= 0.8
+- pysolar
 - pytables
 - pytest
 - pytest-cov
-- python >= 3.6.2  # jjhelmus::tensorflow requires python 3.6
+- python
 - python-dateutil
-- pytorch::pytorch-cpu >= 1.1.0
 - pyyaml
 - qgis
-- rasterio >= 1.0.20
+- bashtage::randomgen
+- rasterio
 - rasterstats
 - recommonmark
 - redis
@@ -154,9 +158,11 @@ dependencies:
 - scikit-learn
 - scipy
 - seaborn
+- setuptools
 - shapely
 - simplejson
 - singledispatch
+- skyfield
 - snuggs
 - spectral
 - sphinx
@@ -168,9 +174,9 @@ dependencies:
 - jjhelmus::tensorflow  # Import issue workaround, https://github.com/conda-forge/tensorflow-feedstock/issues/11
 - tornado
 - tmux
-- pytorch::torchvision-cpu
 - tqdm
 - tuiview
+- typing
 - vega_datasets
 - voluptuous
 - watchdog
@@ -190,7 +196,6 @@ dependencies:
   - dask_labextension
   - DAWG
   - ffmpeg-python
-  - gpytorch  # GPyTorch will not run on PyTorch 0.4.1 or earlier versions
   - graphviz
   - hdmedians
   - jupyterlab-git

--- a/raijin_scripts/deploy/dea/datacube.conf
+++ b/raijin_scripts/deploy/dea/datacube.conf
@@ -12,3 +12,8 @@ db_database: datacube
 db_hostname: agdcdev-db.nci.org.au
 db_port: 6432
 db_database: datacube
+
+[c3-samples]
+db_hostname: 130.56.244.105
+db_port: 6432
+db_database: c3_samples

--- a/raijin_scripts/deploy/dea/modulespec.yaml
+++ b/raijin_scripts/deploy/dea/modulespec.yaml
@@ -34,14 +34,3 @@ template_files:
 
 env_test:
   test_script: "run"
-
-install_dea_proto_libraries:
-# Install dea-proto libraries
-- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_ui&subdirectory=libs/ui'
-- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_index&subdirectory=libs/index'
-- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_aws&subdirectory=libs/aws'
-- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_geom&subdirectory=libs/geom'
-- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_io&subdirectory=libs/io'
-- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_ppt&subdirectory=libs/ppt'
-- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_dscache&subdirectory=libs/dscache'
-- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_dtools&subdirectory=libs/dtools'

--- a/raijin_scripts/deploy/dea/modulespec.yaml
+++ b/raijin_scripts/deploy/dea/modulespec.yaml
@@ -34,3 +34,14 @@ template_files:
 
 env_test:
   test_script: "run"
+
+install_dea_proto_libraries:
+# Install dea-proto libraries
+- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_ui&subdirectory=libs/ui'
+- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_index&subdirectory=libs/index'
+- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_aws&subdirectory=libs/aws'
+- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_geom&subdirectory=libs/geom'
+- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_io&subdirectory=libs/io'
+- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_ppt&subdirectory=libs/ppt'
+- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_dscache&subdirectory=libs/dscache'
+- 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_dtools&subdirectory=libs/dtools'

--- a/raijin_scripts/deploy/dea/requirements.txt
+++ b/raijin_scripts/deploy/dea/requirements.txt
@@ -6,3 +6,11 @@ digitalearthau
 datacube-stats
 fc
 wofs
+odc-ui
+odc-index
+odc-aws
+odc-geom
+odc-io
+odc-ppt
+odc-dscache
+odc-dtools

--- a/raijin_scripts/test_deaenv/run
+++ b/raijin_scripts/test_deaenv/run
@@ -30,7 +30,7 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
-set -x  # echo ON
+
 modname=$(echo "$MODULE" | sed -r "s/[/]+/_/g")
 WORKDIR=/g/data/v10/work/dea_env_test/test"$modname"-$(date '+%d%m%yT%H%M')
 LOGFILE="$WORKDIR"/'Not_World_Readable_Files.log'
@@ -90,8 +90,6 @@ datacube -C "$CONFIGFILE" -E production product show dsm1sv10 > "$WORKDIR/dsm.ya
 
 # Copy yaml files from repo
 sh "$TESTDIR"/dea_testscripts/copy_yaml_files.sh "$WORKDIR" "$TESTDIR"
-
-set +x  # echo OFF
 
 echo "
 ===================================================================

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -33,7 +33,7 @@ do
     _TMP="$(mktemp -d)"
 
     # For now, lets be lazy and install requirements globally
-    if [[ -f requirements.txt ]]; then pip install -r requirements.txt; fi
+    if [[ -f requirements.txt ]]; then pip3 install -r requirements.txt; fi
 
     # Install serverless requirements and run tests
     npm install && npm test

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -38,8 +38,6 @@ do
     # Install serverless requirements and run tests
     npm install && npm test
 
-    serverless config credentials --provider aws --key $aws_access_key_id --secret $aws_secret_access_key --profile prodProfile --overwrite
-
     # Attempt to package the lambda
     echo "writing temporary serverless artifacts to ${_TMP}"
     serverless package -s prod -p "${_TMP}"  # test prod setting

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -38,6 +38,7 @@ do
     # Install serverless requirements and run tests
     npm install && npm test
 
+    serverless config credentials --provider aws --key $aws_access_key_id --secret $aws_secret_access_key --profile prodProfile --overwrite
 
     # Attempt to package the lambda
     echo "writing temporary serverless artifacts to ${_TMP}"


### PR DESCRIPTION
Following are the changes implemented within this PR:

1. In `raijin_scripts/deploy/build_environment_module.py` file:
      - Add `--no-warn-script-location` flag to ignore pip install path for `odc` packages. `pip` `PATH` used is from `dea-env` whereas `pip` path is expecting the `dea` bin path to be  added to `PATH`
      - Update code to install `dea-proto` `odc.*` packages

2. In `raijin_scripts/deploy/dea/datacube.conf` file:
      - Add config setting for `c3` samples

3. In `raijin_scripts/deploy/dea/modulespec.yaml` file:
      - Add `dea-proto` pip install paths

4. In `raijin_scripts/test_deaenv/run` file:
      - Remove redundant logging
