### PR TITLE
Add Zarr to dea-env

### DIFF
--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -188,6 +188,7 @@ dependencies:
 - yamllint
 - yappi
 - yarn
+- zarr
 - pip:
   - apscheduler
   - celery


### PR DESCRIPTION
[Zarr](https://zarr.readthedocs.io/en/stable/) is something we have been meaning to play with for a while now. It may simplify the intermediate steps in our workflow by enabling multiprocess write to disk.