### PR TITLE
Add new python packages to dea-env

### DIFF
--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -13,7 +13,9 @@ It requires python 3.7+ and pyyaml.
 Use a qsub interactive copyq job on raijin with sufficient memory to run the following commands at the NCI:
 New DEA-Env Module
   $ module use /g/data/v10/public/modules/modulefiles/
-  $ module load python3/3.7.2
+  $ module load python3/3.7.4
+  # if pyyaml is not installed in gadi
+  $ pip install PyYAML --user
 
   $ # Building a new Environment Module:
   $ python3 build_environment_module.py dea-env/modulespec.yaml
@@ -105,7 +107,7 @@ def date(date_format="%Y%m%d") -> str:
 
 def _log_output(line):
     try:
-        LOG.info(line.encode('ascii').decode('utf-8'))
+        LOG.info(line)
     except UnicodeEncodeError:
         LOG.warning("UnicodeEncodeError: %s", line.encode('ascii', 'replace'))
 

--- a/raijin_scripts/deploy/build_environment_module.py
+++ b/raijin_scripts/deploy/build_environment_module.py
@@ -9,20 +9,21 @@ It is configured by a YAML file, which specifies:
  - (opt) Conda environment to create
  - (opt) Pip style requirements.txt to install to a directory
 
-It requires python 3.6+ and pyyaml. To run it on raijin at the NCI:
+It requires python 3.7+ and pyyaml.
+Use a qsub interactive copyq job on raijin with sufficient memory to run the following commands at the NCI:
 New DEA-Env Module
   $ module use /g/data/v10/public/modules/modulefiles/
   $ module load python3/3.7.2
 
   $ # Building a new Environment Module:
-  $ ./build_environment_module.py dea-env/modulespec.yaml
+  $ python3 build_environment_module.py dea-env/modulespec.yaml
 
 New DEA Module
   $ module use /g/data/v10/public/modules/modulefiles/
   $ module load python3/3.7.2
 
   $ # Building a new DEA Module
-  $ ./build_environment_module.py dea/modulespec.yaml
+  $ python3 build_environment_module.py dea/modulespec.yaml
 
 It used to be able to perform a miniconda installation, but that turned out to
 be flaky, so we now maintain a central miniconda install, and create environments

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -37,6 +37,7 @@ dependencies:
 - expat
 - eventlet
 - brittainhard::fancyimpute
+- flake8
 - flask
 - flask-caching
 - fiona
@@ -148,7 +149,7 @@ dependencies:
 - rasterio
 - rasterstats
 - recommonmark
-- redis
+- anaconda::redis
 - redis-py
 - anaconda::requests
 - rios
@@ -207,5 +208,6 @@ dependencies:
   - ptpython
   - Py6S
   - pyDEM
+  - pyproj
   - python-intervals
   - requests-aws4auth

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -31,6 +31,7 @@ dependencies:
 - cvxpy
 - cython
 - dask
+- descartes
 - distributed
 - docutils
 - expat

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -4,6 +4,7 @@ channels:
 dependencies:
 - affine
 - attrs
+- autopep8
 - awscli
 - basemap
 - black
@@ -80,7 +81,7 @@ dependencies:
 - jupyter
 - jupyter_contrib_nbextensions
 - jupyter_dashboards
-- jupyterlab
+- conda-forge/label/broken::jupyterlab
 - kealib
 - keras
 - krb5
@@ -188,6 +189,7 @@ dependencies:
 - xgboost
 - yaml
 - yamllint
+- yapf
 - yappi
 - yarn
 - zarr
@@ -201,8 +203,10 @@ dependencies:
   - ffmpeg-python
   - graphviz
   - hdmedians
+  - isort
   - jupyterlab-git
   - jupyter-server-proxy  # port forwards, useful for dask dashboards
+  - jupyterlab_code_formatter
   - libtmux
   - meinheld
   - ptpython

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -81,7 +81,8 @@ dependencies:
 - jupyter
 - jupyter_contrib_nbextensions
 - jupyter_dashboards
-- conda-forge/label/broken::jupyterlab
+- jupyterlab
+- jupyterlab-dash
 - kealib
 - keras
 - krb5
@@ -114,6 +115,7 @@ dependencies:
 - numexpr
 - numpy
 - openjpeg
+- openmp
 - openmpi
 - pandas
 - parallel
@@ -127,7 +129,7 @@ dependencies:
 - plotly
 - poppler
 - poppler-data
-- proj4
+- proj
 - prometheus_client
 - psutil
 - psycopg2

--- a/raijin_scripts/deploy/dea-env/environment.yaml
+++ b/raijin_scripts/deploy/dea-env/environment.yaml
@@ -129,7 +129,9 @@ dependencies:
 - plotly
 - poppler
 - poppler-data
-- proj
+#- proj
+- proj4
+- pyproj
 - prometheus_client
 - psutil
 - psycopg2
@@ -144,6 +146,9 @@ dependencies:
 - pytables
 - pytest
 - pytest-cov
+- pytorch::pytorch
+- pytorch::torchvision
+- anaconda::cudatoolkit
 - python
 - python-dateutil
 - pyyaml
@@ -176,7 +181,7 @@ dependencies:
 - sqlalchemy
 - sqlite
 - structlog
-- jjhelmus::tensorflow  # Import issue workaround, https://github.com/conda-forge/tensorflow-feedstock/issues/11
+- tensorflow
 - tornado
 - tmux
 - tqdm
@@ -214,6 +219,5 @@ dependencies:
   - ptpython
   - Py6S
   - pyDEM
-  - pyproj
   - python-intervals
   - requests-aws4auth

--- a/raijin_scripts/deploy/dea-env/modulefile.template
+++ b/raijin_scripts/deploy/dea-env/modulefile.template
@@ -23,7 +23,7 @@ setenv PYTHONFAULTHANDLER 1
 # This allows users to install python packages with "pip install --user <package>",
 setenv PYTHONUSERBASE ~/.digitalearthau/${module_name}/${module_version}/local
 setenv GDAL_DATA ${module_path}/share/gdal
-setenv PROJ_LIB ${module_path}/lib/python2.7/site-packages/pyproj/data/share/proj
+setenv PROJ_LIB ${module_path}/lib/python3.6/site-packages/pyproj/data
 
 if {[module-info mode load] && [info exists env(PYTHONPATH)] && $$env(PYTHONPATH) != ""} {
         puts stderr "Warning: ${module_name}/${module_version} exists in the python env ($$env(PYTHONPATH))"

--- a/raijin_scripts/deploy/dea-env/modulefile.template
+++ b/raijin_scripts/deploy/dea-env/modulefile.template
@@ -23,7 +23,7 @@ setenv PYTHONFAULTHANDLER 1
 # This allows users to install python packages with "pip install --user <package>",
 setenv PYTHONUSERBASE ~/.digitalearthau/${module_name}/${module_version}/local
 setenv GDAL_DATA ${module_path}/share/gdal
-setenv PROJ_LIB ${module_path}/share/proj
+setenv PROJ_LIB ${module_path}/lib/python2.7/site-packages/pyproj/data/share/proj
 
 if {[module-info mode load] && [info exists env(PYTHONPATH)] && $$env(PYTHONPATH) != ""} {
         puts stderr "Warning: ${module_name}/${module_version} exists in the python env ($$env(PYTHONPATH))"

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -25,6 +25,8 @@ template_files:
   chmod: 0o444
 
 finalise_commands:
+# New geomedian/hdstats package from s3
+- pip install -U -v --no-deps --compile --requirement requirements.txt
 - jupyter labextension install --no-build jupyterlab_bokeh
 - jupyter labextension install --no-build @jupyterlab/geojson-extension
 - jupyter labextension install --no-build @jupyterlab/github
@@ -38,12 +40,10 @@ finalise_commands:
 # To Dask-labextension works well only with 'conda-forge/label/broken' conda version of jupyterlab
 - jupyter labextension install --no-build dask-labextension
 # To Dask-labextension works well only with 'conda-forge/label/cf201901' conda version of jupyterlab
-# - jupyter labextension install --no-build jupyterlab-flake8
+#- jupyter labextension install --no-build jupyterlab-flake8
 - jupyter lab build
 - jupyter serverextension enable --py jupyterlab_git --sys-prefix
 - jupyter serverextension enable --py nbdime --sys-prefix
 - jupyter serverextension enable --py dask_labextension --sys-prefix
 - jupyter serverextension enable --py jupyterlab_code_formatter --sys-prefix
 - jupyter serverextension enable --py jupyter_server_proxy --sys-prefix
-# New geomedian/hdstats package from s3
-- pip install -U -v --no-deps --compile --requirement requirements.txt

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -33,11 +33,14 @@ finalise_commands:
 - jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager
 - jupyter labextension install --no-build jupyter-leaflet
 - jupyter labextension install --no-build nbdime-jupyterlab
+- jupyter labextension install --no-build @ryantam626/jupyterlab_code_formatter
 # To Dask-labextension works well only with 'conda-forge/label/broken' conda version of jupyterlab
 - jupyter labextension install --no-build dask-labextension
 # To Dask-labextension works well only with 'conda-forge/label/cf201901' conda version of jupyterlab
-- jupyter labextension install --no-build jupyterlab-flake8
+# - jupyter labextension install --no-build jupyterlab-flake8
 - jupyter lab build
 - jupyter serverextension enable --py jupyterlab_git --sys-prefix
 - jupyter serverextension enable --py nbdime --sys-prefix
 - jupyter serverextension enable --py dask_labextension --sys-prefix
+- jupyter serverextension enable --py jupyterlab_code_formatter --sys-prefix
+- jupyter serverextension enable --py jupyter_server_proxy --sys-prefix

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -33,7 +33,10 @@ finalise_commands:
 - jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager
 - jupyter labextension install --no-build jupyter-leaflet
 - jupyter labextension install --no-build nbdime-jupyterlab
+# To Dask-labextension works well only with 'conda-forge/label/broken' conda version of jupyterlab
 - jupyter labextension install --no-build dask-labextension
+# To Dask-labextension works well only with 'conda-forge/label/cf201901' conda version of jupyterlab
+- jupyter labextension install --no-build jupyterlab-flake8
 - jupyter lab build
 - jupyter serverextension enable --py jupyterlab_git --sys-prefix
 - jupyter serverextension enable --py nbdime --sys-prefix

--- a/raijin_scripts/deploy/dea-env/modulespec.yaml
+++ b/raijin_scripts/deploy/dea-env/modulespec.yaml
@@ -34,6 +34,7 @@ finalise_commands:
 - jupyter labextension install --no-build jupyter-leaflet
 - jupyter labextension install --no-build nbdime-jupyterlab
 - jupyter labextension install --no-build @ryantam626/jupyterlab_code_formatter
+- jupyter labextension install --no-build jupyterlab-dash@0.1.0-alpha.3
 # To Dask-labextension works well only with 'conda-forge/label/broken' conda version of jupyterlab
 - jupyter labextension install --no-build dask-labextension
 # To Dask-labextension works well only with 'conda-forge/label/cf201901' conda version of jupyterlab
@@ -44,3 +45,5 @@ finalise_commands:
 - jupyter serverextension enable --py dask_labextension --sys-prefix
 - jupyter serverextension enable --py jupyterlab_code_formatter --sys-prefix
 - jupyter serverextension enable --py jupyter_server_proxy --sys-prefix
+# New geomedian/hdstats package from s3
+- pip install -U -v --no-deps --compile --requirement requirements.txt

--- a/raijin_scripts/deploy/dea-env/requirements.txt
+++ b/raijin_scripts/deploy/dea-env/requirements.txt
@@ -1,0 +1,2 @@
+--index-url https://packages.dea.gadevs.ga/
+--no-binary hdstats

--- a/raijin_scripts/deploy/dea-env/requirements.txt
+++ b/raijin_scripts/deploy/dea-env/requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://packages.dea.gadevs.ga/
---no-binary hdstats
+hdstats


### PR DESCRIPTION
## Following are the changes implemented within this PR:

1. Add the following python packages to dea environment yaml file:
     - descartes
     - flake8
     - anaconda::redis
     - autopep8
     - jupyterlab-dash
     - openmp
     - pytorch::pytorch
     - pytorch::torchvision 
     - anaconda::cudatoolkit
     - yapf
     - isort
     - jupyterlab_code_formatter

2. Install `pyproj` using conda instead of pip
3. Fix `PROJ_LIB` template path issue
4. Pip install `hdstats` package from `s3`
5. Add `jupyterlab code formatter`  and `jupyterlab dash` labextensions
6. Minor fixes to environment module python file