### PR TITLE
Update ows/nci database based on SNS message

### DIFF
--- a/lambda_functions/automate_cubedash_db_update/handler.py
+++ b/lambda_functions/automate_cubedash_db_update/handler.py
@@ -25,6 +25,15 @@ def handler(event, context):
     LOG.info("Message ID from Sns: " + event['Records'][0]['Sns']['MessageId'])
     LOG.info("Message timestamp from Sns: " + event['Records'][0]['Sns']['Timestamp'])
 
-    _update_cubedash_db_config(os.environ.get('CUBEDASH_CONFIG'),
-                               message.split('\n')[0],
+    db_name = message.split('\n')[0]
+    if 'nci_' in db_name:
+        update_file = os.environ.get('NCI_EXPLORER_FILE')
+    elif 'ows_' in db_name:
+        update_file = os.environ.get('OWS_EXPLORER_FILE')
+    else:
+        LOG.info("DB Name (" + db_name + ") Error. Config file not updated")
+        exit(1)
+
+    _update_cubedash_db_config(update_file,
+                               db_name,
                                os.environ.get('BITBUCKET_BRANCH'))

--- a/lambda_functions/automate_cubedash_db_update/handler.py
+++ b/lambda_functions/automate_cubedash_db_update/handler.py
@@ -30,6 +30,10 @@ def handler(event, context):
         update_file = os.environ.get('NCI_EXPLORER_FILE')
     elif 'ows_' in db_name:
         update_file = os.environ.get('OWS_EXPLORER_FILE')
+    elif 'sandbox_' in db_name:
+        update_file = os.environ.get('SANDBOX_EXPLORER_FILE')
+    elif 'africa_' in db_name:
+        update_file = os.environ.get('AFRICA_EXPLORER_FILE')
     else:
         LOG.info("DB Name (" + db_name + ") Error. Config file not updated")
         exit(1)

--- a/lambda_functions/automate_cubedash_db_update/serverless.yml
+++ b/lambda_functions/automate_cubedash_db_update/serverless.yml
@@ -59,6 +59,8 @@ provider:
     SSM_USER_PATH: 'orchestrator.raijin.users.default'
     NCI_EXPLORER_FILE: "services/prod_eks_nciexplorer.yaml"
     OWS_EXPLORER_FILE: "services/prod_eks_explorer.yaml"
+    SANDBOX_EXPLORER_FILE: "services/sandbox_explorer.yaml"
+    AFRICA_EXPLORER_FILE: "services/deafrica_explorer.yaml"
     BITBUCKET_BRANCH: ${self:custom.bitbucketbranch.${self:custom.Stage}}
     SNS_TOPIC: ${self:custom.snstopic.${self:custom.Stage}}
 

--- a/lambda_functions/automate_cubedash_db_update/serverless.yml
+++ b/lambda_functions/automate_cubedash_db_update/serverless.yml
@@ -57,7 +57,8 @@ provider:
   # Service wide environment variables declaration
   environment:
     SSM_USER_PATH: 'orchestrator.raijin.users.default'
-    CUBEDASH_CONFIG: "services/prod_eks_nciexplorer.yaml"
+    NCI_EXPLORER_FILE: "services/prod_eks_nciexplorer.yaml"
+    OWS_EXPLORER_FILE: "services/prod_eks_explorer.yaml"
     BITBUCKET_BRANCH: ${self:custom.bitbucketbranch.${self:custom.Stage}}
     SNS_TOPIC: ${self:custom.snstopic.${self:custom.Stage}}
 

--- a/lambda_functions/automate_cubedash_db_update/test_handler.py
+++ b/lambda_functions/automate_cubedash_db_update/test_handler.py
@@ -25,12 +25,12 @@ class TestLambdaFunction(unittest.TestCase):
 
     @patch('handler.boto3.client')
     @patch('handler._update_cubedash_db_config')
-    def test_lambda_handler(self, mock_client, mock_update_cubedash_call):
+    def test_nci_db_update(self, mock_client, mock_update_cubedash_call):
         event = {
             "Records": [
                 {
                     "Sns": {
-                        "Message": "Test message\n",
+                        "Message": "nci_20190101\n",
                         "Timestamp": "Timestamp",
                         "MessageId": "Message_1234"
                     },
@@ -39,3 +39,39 @@ class TestLambdaFunction(unittest.TestCase):
         }
         handler(event, None)
         mock_update_cubedash_call.assert_called
+
+    @patch('handler.boto3.client')
+    @patch('handler._update_cubedash_db_config')
+    def test_ows_db_update(self, mock_client, mock_update_cubedash_call):
+        event = {
+            "Records": [
+                {
+                    "Sns": {
+                        "Message": "ows_20190101\n",
+                        "Timestamp": "Timestamp",
+                        "MessageId": "Message_1234"
+                    },
+                },
+            ]
+        }
+        handler(event, None)
+        mock_update_cubedash_call.assert_called
+
+    @patch('handler.boto3.client')
+    @patch('handler._update_cubedash_db_config')
+    def test_db_name_error(self, mock_client, mock_update_cubedash_call):
+        event = {
+            "Records": [
+                {
+                    "Sns": {
+                        "Message": "20190101\n",
+                        "Timestamp": "Timestamp",
+                        "MessageId": "Message_1234"
+                    },
+                },
+            ]
+        }
+        try:
+            handler(event, None)
+        except SystemExit:
+            mock_update_cubedash_call.assert_called

--- a/lambda_functions/automate_cubedash_db_update/test_handler.py
+++ b/lambda_functions/automate_cubedash_db_update/test_handler.py
@@ -1,6 +1,20 @@
 import unittest
+from unittest.mock import patch as Patch, call
 from mock import patch
 from handler import _update_cubedash_db_config, handler
+from ssh import _connect
+
+
+@Patch('handler.exec_command')
+def test_handler_exec_command(exec_command_mock):
+    exec_command_mock.return_value = "", "", 0
+
+    # Run the Function
+    _update_cubedash_db_config('update_file', 'ows_20190101', 'prod', execute_command=exec_command_mock)
+
+    # Check that the correct arguments are passed to handler.execute_command
+    assert exec_command_mock.call_args == call(
+        'execute_update_cubedash_config --file update_file --dbname ows_20190101 --bitbucket-branch prod')
 
 
 def test_execute_command():

--- a/raijin_scripts/execute_update_cubedash_config/run
+++ b/raijin_scripts/execute_update_cubedash_config/run
@@ -31,12 +31,20 @@ if [ ! -d "$DATAKUBE_APPS_DIR" ]; then
   ssh-agent bash -c "ssh-add $PATH_TO_BITBUCKET_SSH_KEY; git clone $DATAKUBE_APPS_REPO;"
 fi
 
+prefix_db=$(echo "$DB_NAME" | cut -d '_' -f1)
+
+if [[ "$prefix_db" == "sandbox" ]]; then
+  BRANCH="eks-sandbox"
+elif [[ "$prefix_db" == "africa" ]]; then
+  BRANCH="eks-deafrica"
+fi
+
 cd "$DATAKUBE_APPS_DIR" || exit 1  # Changes home folder to be in repo
 ssh-agent bash -c "ssh-add $PATH_TO_BITBUCKET_SSH_KEY; git fetch && git checkout ${BRANCH}; git reset --hard origin/${BRANCH}; git pull"
 
-ssh-agent bash -c "ssh-add $PATH_TO_BITBUCKET_SSH_KEY; 
-   sed -i -E 's/nci_[0-9]*/${DB_NAME}/g' ${DATAKUBE_APPS_DIR}/${UPDATE_FILE}; 
+ssh-agent bash -c "ssh-add $PATH_TO_BITBUCKET_SSH_KEY;
+   sed -i -E 's/${prefix_db}_[0-9]*/${DB_NAME}/g' ${DATAKUBE_APPS_DIR}/${UPDATE_FILE};
    git add ${DATAKUBE_APPS_DIR}/${UPDATE_FILE}; 
-   git commit -m '[skip ci] Updating NCI CubeDash config with new Database name ${DB_NAME}'; 
+   git commit -m '[skip ci] Updating ${prefix_db} explorer config with new database name ${DB_NAME}';
    git push -u origin ${BRANCH}"
 


### PR DESCRIPTION
## Background
`SNS` topic can receive `ows`/`nci` database name. Depending on the database name, `ows`/`nci` explorer configuration file in `datakube-apps` `bitbucket` repo is to be updated.

## Proposed Solution
- In `serverless.yml` file, use separate explorer configuration file
- In `handler.py` file, read the database name from SNS topic. Depending on the database name,  configuration file in `bitbucket` repo shall be updated
- Update pytests