### PR TITLE
Process bitbucket branch name from sns notification

### DIFF
--- a/lambda_functions/automate_cubedash_db_update/handler.py
+++ b/lambda_functions/automate_cubedash_db_update/handler.py
@@ -25,11 +25,15 @@ def handler(event, context):
     LOG.info("Message ID from Sns: " + event['Records'][0]['Sns']['MessageId'])
     LOG.info("Message timestamp from Sns: " + event['Records'][0]['Sns']['Timestamp'])
 
-    db_name = message.split('\n')[0]
+    bit_bucket_branch = message.split(':')[0].strip()
+    db_name = message.split(':')[1].strip()
+
     if 'nci_' in db_name:
         update_file = os.environ.get('NCI_EXPLORER_FILE')
     elif 'ows_' in db_name:
-        update_file = os.environ.get('OWS_EXPLORER_FILE')
+        update_file = os.environ.get('OWS_EXPLORER_FILE') \
+            if bit_bucket_branch == 'eks-prod' else \
+            os.environ.get('OWS_DEV_EXPLORER_FILE')
     elif 'sandbox_' in db_name:
         update_file = os.environ.get('SANDBOX_EXPLORER_FILE')
     elif 'africa_' in db_name:
@@ -40,4 +44,4 @@ def handler(event, context):
 
     _update_cubedash_db_config(update_file,
                                db_name,
-                               os.environ.get('BITBUCKET_BRANCH'))
+                               bit_bucket_branch)

--- a/lambda_functions/automate_cubedash_db_update/serverless.yml
+++ b/lambda_functions/automate_cubedash_db_update/serverless.yml
@@ -59,6 +59,7 @@ provider:
     SSM_USER_PATH: 'orchestrator.raijin.users.default'
     NCI_EXPLORER_FILE: "services/prod_eks_nciexplorer.yaml"
     OWS_EXPLORER_FILE: "services/prod_eks_explorer.yaml"
+    OWS_DEV_EXPLORER_FILE: "services/dev_eks_explorer.yaml"
     SANDBOX_EXPLORER_FILE: "services/sandbox_explorer.yaml"
     AFRICA_EXPLORER_FILE: "services/deafrica_explorer.yaml"
     BITBUCKET_BRANCH: ${self:custom.bitbucketbranch.${self:custom.Stage}}

--- a/lambda_functions/automate_cubedash_db_update/test_handler.py
+++ b/lambda_functions/automate_cubedash_db_update/test_handler.py
@@ -44,7 +44,7 @@ class TestLambdaFunction(unittest.TestCase):
             "Records": [
                 {
                     "Sns": {
-                        "Message": "nci_20190101\n",
+                        "Message": "eks-prod:nci_20190101\n",
                         "Timestamp": "Timestamp",
                         "MessageId": "Message_1234"
                     },
@@ -61,7 +61,7 @@ class TestLambdaFunction(unittest.TestCase):
             "Records": [
                 {
                     "Sns": {
-                        "Message": "ows_20190101\n",
+                        "Message": "eks:ows_20190101\n",
                         "Timestamp": "Timestamp",
                         "MessageId": "Message_1234"
                     },
@@ -78,7 +78,7 @@ class TestLambdaFunction(unittest.TestCase):
             "Records": [
                 {
                     "Sns": {
-                        "Message": "20190101\n",
+                        "Message": "dev:20190101\n",
                         "Timestamp": "Timestamp",
                         "MessageId": "Message_1234"
                     },


### PR DESCRIPTION
## Background
SNS notification message now has the bitbucket branch name prefixed to ows database name. 
This information would help automation to correctly update the helm chart within the respective bitbucket branch