### PR TITLE
Travis Reporting and Deployment Fixes

### DIFF
--- a/lambda_functions/automate_cubedash_db_update/package.json
+++ b/lambda_functions/automate_cubedash_db_update/package.json
@@ -4,7 +4,7 @@
   "description": "Automate cubedash db update",
   "main": "handler.py",
   "scripts": {
-    "test":  "python -m pytest --cov"
+    "test":  "python -m pytest --cov=."
   },
   "author": "Geoscience Australia",
   "license": "Apache 2",

--- a/lambda_functions/nci_monitoring/package.json
+++ b/lambda_functions/nci_monitoring/package.json
@@ -4,7 +4,7 @@
   "description": "Monitor NCI Quotas, PBS Jobs, and datasets processing information on the NCI",
   "main": "nci_quotas_monitor.py, read_nci_email.py",
   "scripts": {
-    "test": "python -m pytest --cov"
+    "test": "python -m pytest --cov=."
   },
   "author": "Geoscience Australia",
   "license": "Apache-2.0",

--- a/lambda_functions/stac/package.json
+++ b/lambda_functions/stac/package.json
@@ -12,6 +12,6 @@
     "serverless-python-requirements": "^4.2.5"
   },
   "scripts": {
-    "test": "python -m pytest --cov"
+    "test": "python -m pytest --cov=."
   }
 }

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -20,7 +20,7 @@ shellcheck -e SC1071,SC1090,SC1091 "${SHELL_SCRIPTS[@]}"
 
 # Run tests on raijin python scripts
 pushd raijin_scripts
-find . -name '*.py' -print0 | xargs -0 pytest -r sx --doctest-ignore-import-errors --cov --durations=5 "$@"
+find . -name '*.py' -print0 | xargs -0 pytest -r sx --doctest-ignore-import-errors --cov=. --durations=5 "$@"
 popd
 
 # Fix for problem with the moto python package, See https://stackoverflow.com/questions/38783140/importerror-no-module-named-google-compute-engine

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -eu
 
 npm install -g serverless
 


### PR DESCRIPTION
- Only report test coverage for the current directory, not every single installed python file
- `chmod +x` the deployment script to see if it'll run on Travis-CI