### PR TITLE
Fix serverless aws configuration issue

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,7 +8,7 @@ for d in lambda_functions/*; do
     pushd "${d}" || exit 1
 
     npm install
-    serverless config credentials --provider aws --key "${AWS_ACCESS_KEY_ID}" --secret "${AWS_SECRET_ACCESS_KEY}" --profile prodProfile
+    serverless config credentials --provider aws --key "${AWS_ACCESS_KEY_ID}" --secret "${AWS_SECRET_ACCESS_KEY}" --profile prodProfile --overwrite
     serverless deploy -v --stage prod
 
     popd || exit 1


### PR DESCRIPTION
- Add `--overwrite` argument to the `sls config credentials` command